### PR TITLE
Additional error reports + Add POLYMOD_STRICT_SYNTAX compiler define

### DIFF
--- a/polymod/hscript/_internal/Expr.hx
+++ b/polymod/hscript/_internal/Expr.hx
@@ -160,6 +160,7 @@ enum Error
   EInvalidIterator(v:String);
   EInvalidOp(op:String);
   EInvalidAccess(f:String);
+  EPrivateField(f:String);
   EInvalidModule(m:String);
   EBlacklistedModule(m:String);
   EBlacklistedField(f:String);

--- a/polymod/hscript/_internal/Expr.hx
+++ b/polymod/hscript/_internal/Expr.hx
@@ -180,6 +180,7 @@ enum Error
   EClassInvalidSuper; // Accessing "super" in a parentless class
   EScriptThrow(v:Dynamic); // Script called "throw"
   EScriptCallThrow(v:Dynamic); // Script called a function which threw
+  EInvalidAccessorCombination(accessors:Array<String>);
   // Fallback error type.
   ECustom(msg:String);
 }

--- a/polymod/hscript/_internal/Interp.hx
+++ b/polymod/hscript/_internal/Interp.hx
@@ -27,6 +27,7 @@ import polymod.util.Util;
 import haxe.PosInfos;
 import haxe.Constraints.IMap;
 
+using Lambda;
 using StringTools;
 
 private enum Stop
@@ -123,23 +124,35 @@ class Interp
       return Type.createInstance(defaultVariables.get(cl), args);
     }
 
+    function tryBuildClass(clsRef:PolymodStaticClassReference, args:Array<Dynamic>):Null<Dynamic>
+    {
+      if (clsRef.cls != getClassDecl() && !clsRef.canInstantiate)
+      {
+        error(ECustom('Cannot access private constructor of "${clsRef.cls.name}"'));
+        return null;
+      }
+      return clsRef.instantiate(args);
+    }
+
     // Try to retrieve a scripted class with this name in the same package.
     if (getClassDecl().pkg != null && getClassDecl().pkg.length > 0)
     {
       var localClassId = getClassDecl().pkg.join('.') + "." + cl;
       var clsRef = PolymodStaticClassReference.tryBuild(localClassId);
-      if (clsRef != null) return clsRef.instantiate(args);
+      if (clsRef != null) return tryBuildClass(clsRef, args);
     }
 
     // Try to retrieve a scripted class with this name in the base package.
     var clsRef = PolymodStaticClassReference.tryBuild(cl);
-    if (clsRef != null) return clsRef.instantiate(args);
+    if (clsRef != null) return tryBuildClass(clsRef, args);
+
     @:privateAccess
     if (getClassDecl().imports != null && getClassDecl().imports.exists(cl))
     {
       var clsRef = PolymodStaticClassReference.tryBuild(getClassDecl().imports.get(cl).fullPath);
-      if (clsRef != null) return clsRef.instantiate(args);
+      if (clsRef != null) return tryBuildClass(clsRef, args);
     }
+
     @:privateAccess
     if (getClassDecl()?.pkg != null)
     {
@@ -148,7 +161,15 @@ class Interp
       if (_scriptClassDescriptors.exists(packagedClass))
       {
         // OVERRIDE CHANGE: Create a PolymodScriptClass instead of a ScriptClass
-        var proxy:PolymodAbstractScriptClass = new PolymodScriptClass(_scriptClassDescriptors.get(packagedClass), args);
+        var clsDescriptor:ClassDecl = findScriptClassDescriptor(packagedClass);
+        var ctorField:Null<FieldDecl> = clsDescriptor.fields.find((f) -> f.name == 'new');
+        if (clsDescriptor != getClassDecl() && ctorField?.access.contains(APrivate))
+        {
+          error(ECustom('Cannot access private constructor of ${clsRef.cls.name}'));
+          return null;
+        }
+
+        var proxy:PolymodAbstractScriptClass = new PolymodScriptClass(clsDescriptor, args);
         return proxy;
       }
     }
@@ -159,7 +180,14 @@ class Interp
       if (_scriptClassDescriptors.exists(importedClass.fullPath))
       {
         // OVERRIDE CHANGE: Create a PolymodScriptClass instead of a ScriptClass
-        var proxy:PolymodAbstractScriptClass = new PolymodScriptClass(_scriptClassDescriptors.get(importedClass.fullPath), args);
+        var clsDescriptor:ClassDecl = findScriptClassDescriptor(importedClass.fullPath);
+        var ctorField:Null<FieldDecl> = clsDescriptor.fields.find((f) -> f.name == 'new');
+        if (clsDescriptor != getClassDecl() && ctorField?.access.contains(APrivate))
+        {
+          error(ECustom('Cannot access private constructor of ${clsRef.cls.name}'));
+          return null;
+        }
+        var proxy:PolymodAbstractScriptClass = new PolymodScriptClass(clsDescriptor, args);
         return proxy;
       }
 
@@ -776,9 +804,7 @@ class Interp
     return assignValue(e1, expr(e2));
   }
 
-  function assignValue(e1:Expr,
-    v:Dynamic,
-    _abstractInlineAssign:Bool = false):Null<Dynamic>
+  function assignValue(e1:Expr, v:Dynamic, _abstractInlineAssign:Bool = false):Null<Dynamic>
   {
     switch (Tools.expr(e1))
     {
@@ -2432,6 +2458,100 @@ class Interp
     return null;
   }
 
+  function checkPrivateAccess(o:Dynamic, f:String):Bool
+  {
+    // First, script classes.
+    if (Std.isOfType(o, PolymodStaticClassReference))
+    {
+      var ref:PolymodStaticClassReference = cast(o, PolymodStaticClassReference);
+
+      // We are retrieving this field within the same script class context.
+      if (o.cls == getClassDecl())
+        return true;
+
+      var field:Null<FieldDecl> = PolymodScriptClass.scriptInterp.getScriptClassStaticFieldDecl(ref.getFullyQualifiedName(), f);
+      if (field != null && field.access.contains(APrivate))
+      {
+        return false;
+      }
+    }
+    else if (Std.isOfType(o, PolymodScriptClass))
+    {
+      var ref:PolymodAbstractScriptClass = cast(o, PolymodAbstractScriptClass);
+
+      if (ref.fullyQualifiedName == getClassFullyQualifiedName())
+        return true;
+
+      // If this script class shares the same superclasses with this class we're in (inheritance) then we can access it if the field is any of those.
+      var superClasses:Array<String> = PolymodScriptClass.getSuperClasses(getClassDecl()) ?? [];
+      var inheritatedSuperClasses:Array<String> = [ref.fullyQualifiedName].concat(PolymodScriptClass.getSuperClasses(ref._c)).filter((superCls:String) -> return superClasses.contains(superCls));
+
+      var superClass:Dynamic = ref.superClass;
+      while (superClass != null)
+      {
+        if (Std.isOfType(superClass, PolymodScriptClass))
+        {
+          var scriptCls:PolymodScriptClass = cast(superClass, PolymodScriptClass);
+          if (inheritatedSuperClasses.contains(scriptCls.fullyQualifiedName))
+          {
+            var fieldDecl = scriptCls.findField(f);
+            if (fieldDecl != null && fieldDecl.access.contains(APrivate))
+            {
+              return true;
+            }
+          }
+          superClass = superClass.superClass;
+        }
+        else
+        {
+          var superClsName:String = Util.getTypeNameOf(superClass);
+          if (inheritatedSuperClasses.contains(superClsName))
+          {
+            if (PolymodFinalMacro.getPrivateFieldsOf(superClsName).contains(f))
+            {
+              return true;
+            }
+          }
+          superClass = Type.getSuperClass(superClass);
+        }
+      }
+
+      // Regular check the script class itself has within the script class itself.
+      var fieldDecl:Null<FieldDecl> = ref.findField(f);
+      if (fieldDecl != null && fieldDecl.access.contains(APrivate))
+      {
+        return false;
+      }
+    }
+    else if (Std.isOfType(o, PolymodStaticAbstractReference))
+    {
+      // Abstracts can't have private instance fields.
+      return true;
+    }
+    else
+    {
+      // We're checking for fields from within a regular class.
+      var superClasses:Array<String> = PolymodScriptClass.getSuperClasses(getClassDecl()) ?? [];
+      var inheritatedSuperClasses:Array<String> = [Util.getTypeNameOf(o)].concat(Util.getSuperClasses(o) ?? []).filter((superCls:String) -> return superClasses.contains(superCls));
+
+      for (cls in inheritatedSuperClasses)
+      {
+        if (PolymodFinalMacro.getPrivateFields(cls).contains(f))
+        {
+          return true;
+        }
+      }
+
+      // Check from within the class itself.
+      if (PolymodFinalMacro.getPrivateFieldsOf(o).contains(f))
+      {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
   function get(o:Dynamic, f:String):Null<Dynamic>
   {
     if (o == null) error(ENullObjectReference(f));
@@ -2446,6 +2566,14 @@ class Interp
 
     var oCls:String = Util.getTypeNameOf(o);
     #if hl oCls = oCls.replace('$', ''); #end
+
+    #if POLYMOD_STRICT_SYNTAX
+    if (!checkPrivateAccess(o, f))
+    {
+      error(EPrivateField(f));
+      return null;
+    }
+    #end
 
     // Check if the field is a blacklisted static field.
     if (PolymodScriptClass.blacklistedStaticFields.exists(o) && PolymodScriptClass.blacklistedStaticFields.get(o).contains(f))
@@ -2562,6 +2690,14 @@ class Interp
 
     var oCls:String = Util.getTypeNameOf(o);
     #if hl oCls = oCls.replace('$', ''); #end
+
+    #if POLYMOD_STRICT_SYNTAX
+    if (!checkPrivateAccess(o, f))
+    {
+      error(EPrivateField(f));
+      return null;
+    }
+    #end
 
     // Check if the field is a blacklisted static field.
     if (PolymodScriptClass.blacklistedStaticFields.exists(o) && PolymodScriptClass.blacklistedStaticFields.get(o).contains(f))

--- a/polymod/hscript/_internal/Interp.hx
+++ b/polymod/hscript/_internal/Interp.hx
@@ -77,6 +77,8 @@ class Interp
   var curExpr:Expr;
   #end
 
+  var inPrivateAccess:Bool = false;
+
   function getClassDecl():Null<ClassDecl>
   {
     if (_classDeclOverride != null)
@@ -2032,8 +2034,17 @@ class Interp
           restore(old);
           return val;
         }
-      case EMeta(_, _, e):
-        return expr(e);
+      case EMeta(name, args, e):
+        switch (name)
+        {
+          case ':privateAccess':
+            inPrivateAccess = true;
+            var obj = expr(e); // We evaulate the expression knowing we're in a private access.
+            inPrivateAccess = false;
+            return obj;
+          default:
+            return expr(e);
+        }
       case ECheckType(e, _):
         return expr(e);
     }
@@ -2568,7 +2579,7 @@ class Interp
     #if hl oCls = oCls.replace('$', ''); #end
 
     #if POLYMOD_STRICT_SYNTAX
-    if (!checkPrivateAccess(o, f))
+    if (!checkPrivateAccess(o, f) && !inPrivateAccess)
     {
       error(EPrivateField(f));
       return null;
@@ -2692,7 +2703,7 @@ class Interp
     #if hl oCls = oCls.replace('$', ''); #end
 
     #if POLYMOD_STRICT_SYNTAX
-    if (!checkPrivateAccess(o, f))
+    if (!checkPrivateAccess(o, f) && !inPrivateAccess)
     {
       error(EPrivateField(f));
       return null;

--- a/polymod/hscript/_internal/Interp.hx
+++ b/polymod/hscript/_internal/Interp.hx
@@ -292,6 +292,15 @@ class Interp
       // Force call super function.
       return o.scriptCallSuper(f, args);
     }
+
+    #if POLYMOD_STRICT_SYNTAX
+    if (!checkPrivateAccess(o, f))
+    {
+      error(EPrivateField(f));
+      return null;
+    }
+    #end
+
     else if (Std.isOfType(o, PolymodStaticAbstractReference))
     {
       var ref:PolymodStaticAbstractReference = cast(o, PolymodStaticAbstractReference);
@@ -2477,6 +2486,10 @@ class Interp
 
   function checkPrivateAccess(o:Dynamic, f:String):Bool
   {
+    // If we're in a private access block, automatically allow it.
+    if (inPrivateAccess)
+      return true;
+
     // First, script classes.
     if (Std.isOfType(o, PolymodStaticClassReference))
     {
@@ -2585,7 +2598,7 @@ class Interp
     #if hl oCls = oCls.replace('$', ''); #end
 
     #if POLYMOD_STRICT_SYNTAX
-    if (!checkPrivateAccess(o, f) && !inPrivateAccess)
+    if (!checkPrivateAccess(o, f))
     {
       error(EPrivateField(f));
       return null;
@@ -2709,7 +2722,7 @@ class Interp
     #if hl oCls = oCls.replace('$', ''); #end
 
     #if POLYMOD_STRICT_SYNTAX
-    if (!checkPrivateAccess(o, f) && !inPrivateAccess)
+    if (!checkPrivateAccess(o, f))
     {
       error(EPrivateField(f));
       return null;

--- a/polymod/hscript/_internal/Interp.hx
+++ b/polymod/hscript/_internal/Interp.hx
@@ -2038,10 +2038,16 @@ class Interp
         switch (name)
         {
           case ':privateAccess':
-            inPrivateAccess = true;
-            var obj = expr(e); // We evaulate the expression knowing we're in a private access.
-            inPrivateAccess = false;
-            return obj;
+            // Check to make sure we aren't already in a private access block.
+            // Otherwise the state'll be overwritten and the original block won't work anymore.
+            if (!inPrivateAccess)
+            {
+              inPrivateAccess = true;
+              var obj = expr(e); // We evaulate the expression knowing we're in a private access.
+              inPrivateAccess = false;
+              return obj;
+            }
+            return expr(e);
           default:
             return expr(e);
         }

--- a/polymod/hscript/_internal/Parser.hx
+++ b/polymod/hscript/_internal/Parser.hx
@@ -1664,9 +1664,17 @@ class Parser
         case "override":
           access.push(AOverride);
         case "public":
-          access.push(APublic);
+          // Throw an error if the user tries declaring a variable as public when it's already been declared private.
+          if (access.contains(APrivate))
+            error(ECustom("Conflicting access modifier public"), currentPos, currentPos);
+          else if (!access.contains(APublic))
+            access.push(APublic);
         case "private":
-          access.push(APrivate);
+          // Throw an error if the user tries declaring a variable as private when it's already been declared public.
+          if (access.contains(APublic))
+            error(ECustom("Conflicting access modifier private"), currentPos, currentPos);
+          else if (!access.contains(APrivate))
+            access.push(APrivate);
         case "inline":
           access.push(AInline);
         case "static":
@@ -1674,6 +1682,11 @@ class Parser
         case "macro":
           access.push(AMacro);
         case "function":
+          if (access.contains(AOverride) && access.contains(AStatic))
+          {
+            error(EInvalidAccessorCombination(['override', 'static']), currentPos, currentPos);
+          }
+
           var name = getIdent();
           var inf = parseFunctionDecl();
           maybe(TSemicolon);
@@ -1713,6 +1726,13 @@ class Parser
           }
           else
             ensure(TSemicolon);
+
+          #if POLYMOD_STRICT_SYNTAX
+          if (access.contains(AInline) && !access.contains(AStatic))
+          {
+            error(ECustom('Invalid modifier: inline on non-static variable'), currentPos, currentPos);
+          }
+          #end
 
           return {
             name: name,

--- a/polymod/hscript/_internal/Parser.hx
+++ b/polymod/hscript/_internal/Parser.hx
@@ -104,6 +104,8 @@ class Parser
   var idents:Array<Bool>;
   var uid:Int = 0;
 
+  var packageSet:Bool = false;
+
   #if hscriptPos
   var origin:String;
   var tokenMin:Int;
@@ -1463,6 +1465,13 @@ class Parser
     switch (ident)
     {
       case "package":
+        #if POLYMOD_STRICT_SYNTAX
+        if (!packageSet)
+          packageSet = true;
+        else
+          error(ECustom("Unknown identifier: package"), currentPos, currentPos); // Throw an error if there was a package already set.
+        #end
+
         var path = parsePath();
         ensure(TSemicolon);
         return DPackage(path);

--- a/polymod/hscript/_internal/PolymodFinalMacro.hx
+++ b/polymod/hscript/_internal/PolymodFinalMacro.hx
@@ -1,5 +1,6 @@
 package polymod.hscript._internal;
 
+import haxe.macro.Type.ClassField;
 #if macro
 import haxe.macro.Context;
 import haxe.macro.Expr;
@@ -15,6 +16,34 @@ class PolymodFinalMacro
   static inline final METADATA_RESOURCE_NAME:String = 'PolymodFinalMacro_METADATA';
 
   #if !macro
+  private static var _allFinals:Null<Map<String, Array<String>>> = null;
+  private static var _allPrivateProperties:Null<Map<String, Array<String>>> = null;
+  private static var _allPrivatesFields:Null<Map<String, Array<String>>> = null;
+
+  public static function getAllFinals():Map<String, Array<String>>
+  {
+    if (_allFinals == null) _allFinals = PolymodFinalMacro.fetchAllFinals();
+    return _allFinals;
+  }
+
+  public static function getAllPrivateProperties():Map<String, Array<String>>
+  {
+    if (_allPrivateProperties == null) _allPrivateProperties = PolymodFinalMacro.fetchAllPrivateProperties();
+    return _allPrivateProperties;
+  }
+
+  public static function getAllPrivateFields():Map<String, Array<String>>
+  {
+    #if POLYMOD_STRICT_SYNTAX
+    if (_allPrivatesFields == null) _allPrivatesFields = PolymodFinalMacro.fetchAllPrivateFields();
+    #else
+    // Disable private fields.
+    if (_allPrivatesFields == null) _allPrivatesFields = [];
+    #end
+
+    return _allPrivatesFields;
+  }
+
   public static inline function getFinals(fullPath:String):Array<String> {
     return getAllFinals().get(fullPath) ?? [];
   }
@@ -39,22 +68,20 @@ class PolymodFinalMacro
     return result;
   }
 
-  private static var _allFinals:Null<Map<String, Array<String>>> = null;
-
-  public static function getAllFinals():Map<String, Array<String>>
-  {
-    if (_allFinals == null) _allFinals = PolymodFinalMacro.fetchAllFinals();
-    return _allFinals;
+  public static inline function getPrivateFields(fullPath:String):Array<String> {
+    return getAllPrivateFields().get(fullPath) ?? [];
   }
 
-  private static var _allPrivates:Null<Map<String, Array<String>>> = null;
+  public static inline function getPrivateFieldsOf(obj:Dynamic):Array<String> {
+    while (Std.isOfType(obj, PolymodScriptClass)) obj = obj.superClass;
 
-  public static function getAllPrivateProperties():Map<String, Array<String>>
-  {
-    if (_allPrivates == null) _allPrivates = PolymodFinalMacro.fetchAllPrivateProperties();
-    return _allPrivates;
+    var typeName:String = polymod.util.Util.getTypeNameOf(obj);
+    var result = getPrivateFields(typeName);
+    return result;
   }
   #end
+
+  static var calledBefore:Bool = false;
 
   public static macro function locateAllFinals():Void
   {
@@ -64,7 +91,8 @@ class PolymodFinalMacro
       var startTime:Float = Sys.time();
 
       var allFinals:Array<Dynamic> = [];
-      var allPrivates:Array<Dynamic> = [];
+      var allPrivateProperties:Array<Dynamic> = [];
+      var allPrivateFields:Array<Dynamic> = [];
 
       for (type in types)
       {
@@ -84,13 +112,21 @@ class PolymodFinalMacro
               allFinals.push(entryData);
             }
 
-            var privates:Array<String> = listPrivateFields(fields);
-            if (privates.length > 0)
+            var privatesProperties:Array<String> = listPrivateProperties(fields);
+            if (privatesProperties.length > 0)
             {
-              var entryData:Array<Dynamic> = [classPath, privates];
-              allPrivates.push(entryData);
+              var entryData:Array<Dynamic> = [classPath, privatesProperties];
+              allPrivateProperties.push(entryData);
             }
 
+            #if POLYMOD_STRICT_SYNTAX
+            var privateFields:Array<String> = listPrivateFields(fields);
+            if (privateFields.length > 0)
+            {
+              var entryData:Array<Dynamic> = [classPath, privateFields];
+              allPrivateFields.push(entryData);
+            }
+            #end
           default:
             continue;
         }
@@ -98,7 +134,8 @@ class PolymodFinalMacro
 
       var metadataHXSF = haxe.Serializer.run({
         finals: allFinals,
-        privates: allPrivates
+        privateProperties: allPrivateProperties,
+        privateFields: allPrivateFields,
       });
       Context.addResource(METADATA_RESOURCE_NAME, haxe.io.Bytes.ofString(metadataHXSF));
 
@@ -108,7 +145,8 @@ class PolymodFinalMacro
 
       Context.info('PolymodFinalMacro: '
         + 'Detected ${allFinals.length} classes with final variables, '
-        + '${allPrivates.length} classes with (default,null) properties '
+        + '${allPrivateProperties.length} classes with (default,null) properties, '
+        + '${allPrivateFields.length} classes with private variables '
         + 'in ${duration} sec.',
         Context.currentPos());
 
@@ -165,7 +203,7 @@ class PolymodFinalMacro
     return result;
   }
 
-  static function listPrivateFields(fields:Array<ClassField>):Array<String>
+  static function listPrivateProperties(fields:Array<ClassField>):Array<String>
   {
     var result:Array<String> = [];
 
@@ -183,7 +221,16 @@ class PolymodFinalMacro
     return result;
   }
 
-  static var calledBefore:Bool = false;
+  static function listPrivateFields(fields:Array<ClassField>):Array<String>
+  {
+    var result:Array<String> = [];
+    for (field in fields)
+    {
+      if (field.isPublic) continue;
+      result.push(field.name);
+    }
+    return result;
+  }
   #end
 
   public static function fetchAllFinals():Map<String, Array<String>>
@@ -216,7 +263,7 @@ class PolymodFinalMacro
   public static function fetchAllPrivateProperties():Map<String, Array<String>>
   {
     var metaData = fetchMetadata();
-    var privates:Array<Dynamic> = cast metaData.privates;
+    var privates:Array<Dynamic> = cast metaData.privateProperties;
 
     if (privates != null)
     {
@@ -224,7 +271,7 @@ class PolymodFinalMacro
 
       for (element in privates)
       {
-        if (element.length != 2) throw 'Malformed element in privates: ' + element;
+        if (element.length != 2) throw 'Malformed element in privates properties: ' + element;
 
         var classPath:String = element[0];
         var privates:Array<String> = element[1];
@@ -237,6 +284,32 @@ class PolymodFinalMacro
     else
     {
       throw 'No private properties found in PolymodFinalMacro';
+    }
+  }
+
+  public static function fetchAllPrivateFields():Map<String, Array<String>>
+  {
+    var metaData = fetchMetadata();
+    var privateVars:Array<Dynamic> = cast metaData.privateFields;
+
+    if (privateVars != null)
+    {
+      var result:Map<String, Array<String>> = [];
+
+      for (element in privateVars)
+      {
+        if (element.length != 2) throw 'Malformed element in private fields: ' + element;
+
+        var classPath:String = element[0];
+        var privates:Array<String> = element[1];
+
+        result.set(classPath, privates);
+      }
+      return result;
+    }
+    else
+    {
+      throw 'No private fields found in PolymodFinalMacro';
     }
   }
 

--- a/polymod/hscript/_internal/PolymodScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodScriptClass.hx
@@ -399,6 +399,11 @@ class PolymodScriptClass
           Polymod.error(SCRIPT_PARSE_FAILED,
             'Error while parsing class ${path}#${errLine}: EClassUnresolvedSuperclass' + '\n' + 'Unresolved superclass "${cls}", ${reason}', SCRIPT_RUNTIME);
           return false;
+        case EInvalidAccessorCombination(accessors):
+          Polymod.error(
+            SCRIPT_PARSE_FAILED,
+            'Error while parsing function ${path}#${errLine}: EInvalidAccessorCombination' + '\n' + 'Invalid modifier combination: ${accessors.join(' + ')}', SCRIPT_RUNTIME);
+            return false;
         default:
           Polymod.error(SCRIPT_PARSE_FAILED, 'Error while parsing script ${path}#${errLine}: ' + '\n' + 'An unknown error occurred: ${err}', SCRIPT_RUNTIME);
           return false;
@@ -897,7 +902,6 @@ class PolymodScriptClass
       superClass = Type.createInstance(clsToCreate, args);
     }
 
-    // Throw an error if the script class has an instance field with the same name as one from the super class.
     for (f in _c.fields)
     {
       switch (f.kind)
@@ -905,10 +909,39 @@ class PolymodScriptClass
         case KVar(v):
           if (!f.access.contains(AStatic) && superHasField(f.name))
           {
-            throw 'Redefinition of variable "${f.name}" from superclass not allowed';
+            // Throw an error if the script class has an instance field with the same name as one from the super class.
+            throw 'Redefinition of variable "${f.name}" from superclass not allowed.';
           }
+        case KFunction(fn):
+          #if POLYMOD_STRICT_SYNTAX
+          if (f.access.contains(AOverride) && !superHasField(f.name))
+          {
+            // Throw an error if a function is declared overwritten but isn't overriding anything.
+            throw "Field " + f.name + " is declared 'override' but doesn't override any field.";
+          }
+          else if (!f.access.contains(AOverride) && superHasField(f.name))
+          {
+            var superClassPackage:String = '';
+            if (superClass is PolymodScriptClass)
+            {
+              superClassPackage = Util.getFullClassName((cast superClass : PolymodScriptClass)._c);
+            }
+            else
+            {
+              // TODO: Fetch entire package name?
+              superClassPackage = Util.getTypeNameOf(superClass);
+            }
 
-        case _:
+            // Throw an error if a function is overriden but doesn't have the override accessor.
+            throw "Field " + f.name + " should be declared with 'override' since it is inherited from superclass " + superClassPackage + '.';
+          }
+          else if (f.access.contains(AOverride) && superClass == null)
+          {
+            // Throw an error if the override accessor is used with no super class.
+            throw "Invalid modifier: override on field" + f.name + " of class that has no parent.";
+          }
+          #end
+        default:
       }
     }
   }

--- a/polymod/hscript/_internal/PolymodScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodScriptClass.hx
@@ -794,6 +794,8 @@ class PolymodScriptClass
       createSuperClass(args);
     }
     _constructorArgs = args;
+
+    validateClassFields();
   }
 
   var __superClassFieldList:Array<String> = null;
@@ -901,7 +903,10 @@ class PolymodScriptClass
 
       superClass = Type.createInstance(clsToCreate, args);
     }
+  }
 
+  private function validateClassFields():Void
+  {
     for (f in _c.fields)
     {
       switch (f.kind)

--- a/polymod/hscript/_internal/PolymodStaticClassReference.hx
+++ b/polymod/hscript/_internal/PolymodStaticClassReference.hx
@@ -3,6 +3,7 @@ package polymod.hscript._internal;
 import polymod.hscript._internal.Expr;
 import polymod.util.Util;
 
+using Lambda;
 using StringTools;
 
 /**
@@ -13,6 +14,14 @@ using StringTools;
 class PolymodStaticClassReference
 {
   public var cls:Null<ClassDecl>;
+
+  public var canInstantiate(get, never):Bool;
+
+  public function get_canInstantiate():Bool
+  {
+    var ctorField = cls.fields.find((f) -> f.name == 'new');
+    return !ctorField.access.contains(APrivate);
+  }
 
   public function new(?cls:ClassDecl)
   {

--- a/polymod/hscript/_internal/Printer.hx
+++ b/polymod/hscript/_internal/Printer.hx
@@ -683,8 +683,8 @@ class Printer
       if (m.params != null)
       {
         output += "(";
-        for (i in 0...m.params.length)
-        {
+      for (i in 0...m.params.length)
+      {
           var param:Expr = m.params[i];
           output += this.exprToString(param);
           if (i < m.params.length - 1) output += ", ";
@@ -726,6 +726,7 @@ class Printer
       case EInvalidIterator(v): 'Invalid iterator "$v".';
       case EInvalidOp(op): 'Invalid operator "$op".';
       case EInvalidAccess(f): 'Invalid access to field "$f".';
+      case EPrivateField(f): 'Cannot access private field "$f".';
       case EInvalidModule(m): 'Invalid module "$m".';
       case EBlacklistedModule(m): 'Blacklisted module "$m".';
       case EBlacklistedField(m): 'Blacklisted field "$m".';

--- a/polymod/hscript/_internal/Printer.hx
+++ b/polymod/hscript/_internal/Printer.hx
@@ -747,6 +747,7 @@ class Printer
       // TODO: Do we need to distinguish these?
       case EScriptCallThrow(v): 'Script threw an exception:\n$v';
       case EScriptThrow(v): 'User script threw an exception:\n$v';
+      case EInvalidAccessorCombination(accessors): 'Invalid modifier combination: ${accessors.join(' + ')}';
       case ECustom(msg): msg;
     };
     #if hscriptPos

--- a/polymod/util/Util.hx
+++ b/polymod/util/Util.hx
@@ -736,6 +736,23 @@ class Util
     return errorMessage;
   }
 
+  public static function getSuperClasses(obj:Dynamic):Array<String>
+  {
+    var cls = Type.getClass(obj) ?? Type.resolveClass(getTypeNameOf(obj));
+    if (cls == null) return [];
+
+    var superCls:Dynamic = Type.getSuperClass(cls);
+    if (superCls == null) return [];
+
+    var superClassList:Array<String> = [];
+    while (superCls != null)
+    {
+      superClassList.push(Type.getClassName(superCls));
+      superCls = Type.getSuperClass(superCls);
+    }
+    return superClassList;
+  }
+
   public static function getTypeNameOf(obj:Dynamic):String
   {
     var type = Type.typeof(obj);


### PR DESCRIPTION
This PR adds a couple of new error reports to scripted classes including:
- Error when trying to set a variable to be private when it's already public, vice versa.
- Error when there's an overriding function that's also static.
- Error when trying to instantiate a scripted class with a private constructor.

This also adds an additional compiler define "POLYMOD_STRICT_SYNTAX"

This compiler define is as you can guess for if the user wants scripts to have syntax handling to be more similar to Haxe, thus having it be more stricter on when errors are thrown and such. This compiler define also disallows the use of private variables completely.

Right now this define includes error reporting for:
- Having a function that overrides a super class function but doesn't use the override accessor
- Having a function with the override accessor that doesn't override anything
- Having a function with the override accessor with no parent class.
- Having a variable that's inline but also isn't static.
- Trying to retrieve a private field of a class that doesn't share inheritance. 


<img width="694" height="196" alt="image" src="https://github.com/user-attachments/assets/0c129902-6186-4100-ab53-63641c9d5d57" />

<img width="769" height="246" alt="image" src="https://github.com/user-attachments/assets/f6597f15-e2f2-4e46-8842-b0a904f47cd4" />
