### PR TITLE
[SECURITY] Fix constructing classes ignoring blacklists.

### DIFF
--- a/polymod/hscript/_internal/Interp.hx
+++ b/polymod/hscript/_internal/Interp.hx
@@ -177,11 +177,8 @@ class Interp
       error(EBlacklistedModule(importedClass.fullPath));
     }
 
-    // Attempt to resolve the class without overrides.
-    var cls = Type.resolveClass(cl);
-    if (cls == null) cls = resolve(cl);
-    if (cls == null) error(EInvalidModule(cl));
-    return Type.createInstance(cls, args);
+    // Don't try to resolve classes without a valid import.
+    error(EInvalidModule(cl));
   }
 
   private var _nextCallObject:Dynamic = null;


### PR DESCRIPTION
This PR fixes an issue where you could construct a class by its full path regardless if it was imported, or blacklisted.

This change prevents constructing blacklisted classes but it also prevents constructing any class that isn't imported, which may negatively affect backwards compatibility.