### PR TITLE
CPPIA support as added backend

### DIFF
--- a/polymod/Polymod.hx
+++ b/polymod/Polymod.hx
@@ -836,6 +836,47 @@ class Polymod
   }
 
   /**
+   * Whether an object came from a script rather than from the game.
+   * @param target The object to check. Null is not scripted.
+   */
+  public static function isScriptedClass(target:Dynamic):Bool
+  {
+    if (target == null) return false;
+
+    if (Std.isOfType(target, polymod.hscript.HScriptedClass)) return true;
+
+    try
+    {
+      if (Reflect.field(target, '_asc') != null) return true;
+    }
+    catch (_:Dynamic) {}
+
+    return isCompiledScriptClass(target);
+  }
+
+  /**
+   * Whether an object's class was declared by a compiled (cppia) script.
+   *
+   * @param target The object to check. Null is not scripted.
+   */
+  public static function isCompiledScriptClass(target:Dynamic):Bool
+  {
+    #if (hxcpp && POLYMOD_CPPIA)
+    if (target == null) return false;
+
+    var cls:Null<Class<Dynamic>> = Type.getClass(target);
+    if (cls == null) return false;
+
+    var name:Null<String> = Type.getClassName(cls);
+    if (name == null) return false;
+
+    return polymod.hscript._internal.PolymodCppiaClassReference.isScriptClass(name);
+    #else
+    return false;
+    #end
+  }
+
+  /**
    * Clears all scripted functions and any registered scripted classes from the cache.
    * This is useful if you want to reload the scripts later.
    */

--- a/polymod/Polymod.hx
+++ b/polymod/Polymod.hx
@@ -876,7 +876,9 @@ class Polymod
     @:privateAccess {
       var libraryIds:Array<String> = Polymod.assetLibrary.listLibraries();
 
-      for (binaryPath in Polymod.assetLibrary.list(BYTES))
+      var allBytes:Array<String> = Polymod.assetLibrary.list(BYTES);
+
+      for (binaryPath in allBytes)
       {
         if (!PolymodConfig.cppiaClassExt.exists(ext -> binaryPath.endsWith(ext))) continue;
 
@@ -914,11 +916,13 @@ class Polymod
         var registered = polymod.hscript._internal.PolymodCppiaClassReference.registerModule(data, path);
         results.set(path, registered.length > 0);
 
-        if (registered.length > 0)
+        if (registered.length == 0)
         {
-          Polymod.info(SCRIPT_PARSE_DONE, 'Loaded compiled script "$path" providing ${registered.join(", ")}');
+          Polymod.warning(SCRIPT_PARSE_FAILED,
+            'Compiled script "$path" registered no classes, so nothing in it can be used.', SCRIPT_RUNTIME);
         }
       }
+      polymod.hscript._internal.PolymodCppiaClassReference.unloadInactiveModules();
     }
     #end
   }

--- a/polymod/Polymod.hx
+++ b/polymod/Polymod.hx
@@ -843,6 +843,9 @@ class Polymod
   {
     @:privateAccess
     polymod.hscript._internal.PolymodScriptClass.clearScriptedClasses();
+    #if POLYMOD_CPPIA
+    polymod.hscript._internal.PolymodCppiaClassReference.clearCppiaClasses();
+    #end
     polymod.hscript._internal.PolymodEnum.clearScriptedEnums();
     #if hscript_typer
     polymod.hscript._internal.PolymodTyperEx.clearAllModules();
@@ -861,12 +864,64 @@ class Polymod
       Parser.preprocessorValues.set(mod.id, mod.modVersion.toString());
     }
   }
-
   /**
-   * Get a list of all the available scripted classes (`.hxc` files), interpret them, and register any classes.
-   *
-   * @return A map of script class paths to whether they were successfully parsed and registered.
+   * Loads all compiled scripts (`.cppia` files) and registers any classes they provide.
    */
+  static function registerAllCppiaClasses(?results:Map<String, Bool>):Void
+  {
+    if (results == null) results = [];
+
+    #if POLYMOD_CPPIA
+    @:privateAccess {
+      var libraryIds:Array<String> = Polymod.assetLibrary.listLibraries();
+
+      for (binaryPath in Polymod.assetLibrary.list(BYTES))
+      {
+        if (!PolymodConfig.cppiaClassExt.exists(ext -> binaryPath.endsWith(ext))) continue;
+
+        var path = binaryPath;
+        if (!Polymod.assetLibrary.exists(path))
+        {
+          for (libraryId in libraryIds)
+          {
+            if (Polymod.assetLibrary.exists('$libraryId:$binaryPath'))
+            {
+              path = '$libraryId:$binaryPath';
+              break;
+            }
+          }
+          if (!Polymod.assetLibrary.exists(path))
+          {
+            Polymod.error(SCRIPT_NOT_FOUND, 'Could not find file "$binaryPath"');
+            results.set(path, false);
+            continue;
+          }
+        }
+
+        var data:haxe.io.Bytes = null;
+        try
+        {
+          data = Polymod.assetLibrary.getBytes(path);
+        }
+        catch (e:Dynamic)
+        {
+          Polymod.error(SCRIPT_NOT_FOUND, 'Could not read compiled script "$path": $e');
+          results.set(path, false);
+          continue;
+        }
+
+        var registered = polymod.hscript._internal.PolymodCppiaClassReference.registerModule(data, path);
+        results.set(path, registered.length > 0);
+
+        if (registered.length > 0)
+        {
+          Polymod.info(SCRIPT_PARSE_DONE, 'Loaded compiled script "$path" providing ${registered.join(", ")}');
+        }
+      }
+    }
+    #end
+  }
+
   public static function registerAllScriptClasses():Map<String, Bool>
   {
     Polymod.info(SCRIPT_PARSE_START, 'Parsing script classes...');
@@ -905,6 +960,8 @@ class Polymod
         }
       }
 
+      registerAllCppiaClasses(results);
+
       #if hscript_typer
       // in the future typed modules might have a use
       // but for now we just ignore the typed modules that are returned
@@ -928,6 +985,8 @@ class Polymod
   {
     Polymod.info(SCRIPT_PARSE_START, 'Parsing script classes asynchronously...');
     prepareRegisterScriptedClasses();
+
+    registerAllCppiaClasses();
 
     // Go through each script and parse any classes in them.
     var potentialScripts:Array<String> = Polymod.assetLibrary.list(TEXT);

--- a/polymod/Polymod.hx
+++ b/polymod/Polymod.hx
@@ -864,6 +864,7 @@ class Polymod
       Parser.preprocessorValues.set(mod.id, mod.modVersion.toString());
     }
   }
+
   /**
    * Loads all compiled scripts (`.cppia` files) and registers any classes they provide.
    */
@@ -922,6 +923,9 @@ class Polymod
     #end
   }
 
+  /**
+   * Loads all script classes (`.hxc` files) and registers any classes they provide.
+   */
   public static function registerAllScriptClasses():Map<String, Bool>
   {
     Polymod.info(SCRIPT_PARSE_START, 'Parsing script classes...');

--- a/polymod/Polymod.hx
+++ b/polymod/Polymod.hx
@@ -878,10 +878,12 @@ class Polymod
 
       var allBytes:Array<String> = Polymod.assetLibrary.list(BYTES);
 
-      for (binaryPath in allBytes)
-      {
-        if (!PolymodConfig.cppiaClassExt.exists(ext -> binaryPath.endsWith(ext))) continue;
+      var cppiaPaths:Array<String> = allBytes.filter(path -> PolymodConfig.cppiaClassExt.exists(ext -> path.endsWith(ext)));
 
+      cppiaPaths = polymod.hscript._internal.PolymodCppiaTarget.select(cppiaPaths);
+
+      for (binaryPath in cppiaPaths)
+      {
         var path = binaryPath;
         if (!Polymod.assetLibrary.exists(path))
         {

--- a/polymod/Polymod.hx
+++ b/polymod/Polymod.hx
@@ -970,6 +970,88 @@ class Polymod
     #end
   }
 
+  static function registerAllCppiaClassesAsync():Array<lime.app.Future<Bool>>
+  {
+    #if POLYMOD_CPPIA
+    @:privateAccess {
+      var libraryIds:Array<String> = Polymod.assetLibrary.listLibraries();
+      var allBytes:Array<String> = Polymod.assetLibrary.list(BYTES);
+      var cppiaPaths:Array<String> = allBytes.filter(path -> PolymodConfig.cppiaClassExt.exists(ext -> path.endsWith(ext)));
+
+      cppiaPaths = polymod.hscript._internal.PolymodCPPIATarget.select(cppiaPaths);
+
+      var futures:Array<lime.app.Future<Bool>> = [];
+      for (binaryPath in cppiaPaths)
+      {
+        var path:String = binaryPath;
+        if (!Polymod.assetLibrary.exists(path))
+        {
+          for (libraryId in libraryIds)
+          {
+            if (Polymod.assetLibrary.exists('$libraryId:$binaryPath'))
+            {
+              path = '$libraryId:$binaryPath';
+              break;
+            }
+          }
+          if (!Polymod.assetLibrary.exists(path))
+          {
+            Polymod.error(SCRIPT_NOT_FOUND, 'Could not find file "$binaryPath"');
+            continue;
+          }
+        }
+
+        var promise = new lime.app.Promise<Bool>();
+
+        futures.push(promise.future);
+        try
+        {
+          Polymod.assetLibrary.loadBytes(path).onComplete((bytes:Bytes) ->
+          {
+            try
+            {
+              var registered = polymod.hscript._internal.PolymodCppiaClassReference.registerModule(bytes, path);
+              if (registered.length == 0)
+              {
+                Polymod.warning(SCRIPT_PARSE_FAILED, 'Compiled script "$path" registered no classes, so nothing in it can be used.', SCRIPT_RUNTIME);
+              }
+              promise.complete(true);
+            }
+            catch (e)
+            {
+              promise.error(e);
+            }
+          }).onError((err) ->
+            {
+              if (err == '404')
+              {
+                Polymod.error(
+                  SCRIPT_PARSE_FAILED,
+                  'Error while loading compiled script "${path}", could not retrieve script contents (404 error)!',
+                  SCRIPT_RUNTIME
+                );
+              }
+              else
+              {
+                Polymod.error(SCRIPT_PARSE_FAILED, 'Error while parsing script ${path}: ' + '\n' + 'An unknown error occurred: ${err}', SCRIPT_RUNTIME);
+              }
+              promise.error(err);
+            });
+        }
+        catch (e:Dynamic)
+        {
+          Polymod.error(SCRIPT_NOT_FOUND, 'Could not read compiled script "$path": $e');
+          promise.error(e);
+          continue;
+        }
+      }
+      return futures;
+    }
+    #else
+    return [];
+    #end
+  }
+
   /**
    * Loads all script classes (`.hxc` files) and registers any classes they provide.
    */
@@ -1037,13 +1119,15 @@ class Polymod
     Polymod.info(SCRIPT_PARSE_START, 'Parsing script classes asynchronously...');
     prepareRegisterScriptedClasses();
 
-    registerAllCppiaClasses();
+    var futures:Array<lime.app.Future<Bool>> = [];
+
+    // Load CPPIA scripts first asynchronously
+    futures = futures.concat(registerAllCppiaClassesAsync());
 
     // Go through each script and parse any classes in them.
     var potentialScripts:Array<String> = Polymod.assetLibrary.list(TEXT);
     var libraryIds:Array<String> = Polymod.assetLibrary.listLibraries();
 
-    var futures:Array<lime.app.Future<Bool>> = [];
     for (textPath in potentialScripts)
     {
       if (PolymodConfig.scriptClassExt.exists(ext -> textPath.endsWith(ext)))
@@ -1067,6 +1151,10 @@ class Polymod
     }
 
     return lime.app.Promise.allSettled(futures).then((results) -> {
+      #if POLYMOD_CPPIA
+      polymod.hscript._internal.PolymodCppiaClassReference.unloadInactiveModules();
+      #end
+
       // Once all scripts have been registered, THEN validate the imports.
       polymod.hscript._internal.Interp.validateImports();
 

--- a/polymod/Polymod.hx
+++ b/polymod/Polymod.hx
@@ -880,7 +880,7 @@ class Polymod
 
       var cppiaPaths:Array<String> = allBytes.filter(path -> PolymodConfig.cppiaClassExt.exists(ext -> path.endsWith(ext)));
 
-      cppiaPaths = polymod.hscript._internal.PolymodCppiaTarget.select(cppiaPaths);
+      cppiaPaths = polymod.hscript._internal.PolymodCPPIATarget.select(cppiaPaths);
 
       for (binaryPath in cppiaPaths)
       {

--- a/polymod/Polymod.hx
+++ b/polymod/Polymod.hx
@@ -1162,6 +1162,7 @@ class Polymod
   public static function addImportAlias(importAlias:String, importClass:Class<Dynamic>):Void
   {
     PolymodScriptClass.importOverrides.set(importAlias, importClass);
+    PolymodScriptClass.bumpBlacklistGeneration();
   }
 
   /**
@@ -1200,6 +1201,7 @@ class Polymod
   public static function blacklistStaticFields(parentClass:Class<Dynamic>, fields:Array<String>):Void
   {
     PolymodScriptClass.blacklistedStaticFields.set(parentClass, fields);
+    PolymodScriptClass.bumpBlacklistGeneration();
   }
 
   /**
@@ -1210,6 +1212,19 @@ class Polymod
   public static function blacklistInstanceFields(parentClass:Class<Dynamic>, fields:Array<String>):Void
   {
     PolymodScriptClass.blacklistedInstanceFields.set(Type.getClassName(parentClass), fields);
+    PolymodScriptClass.bumpBlacklistGeneration();
+  }
+
+  /**
+   * Blacklist a field by name alone, on any class and on none.
+   * @param fields The field names no script may use.
+   */
+  public static function blacklistDynamicFieldNames(fields:Array<String>):Void
+  {
+    for (field in fields)
+      PolymodScriptClass.blacklistedDynamicFieldNames.set(field, true);
+
+    PolymodScriptClass.bumpBlacklistGeneration();
   }
 }
 

--- a/polymod/PolymodConfig.hx
+++ b/polymod/PolymodConfig.hx
@@ -97,6 +97,22 @@ class PolymodConfig
   }
 
   /**
+   * The file extension for compiled (cppia) scripted class files.
+   *
+   * Set this option by setting the `POLYMOD_CPPIA_CLASS_EXT` Haxe define at compile time,
+   * or by setting this value in your code. You can provide multiple values by separating them with commas.
+   *
+   * @default `.cppia`
+   */
+  public static var cppiaClassExt(get, default):Array<String>;
+
+  static function get_cppiaClassExt():Array<String>
+  {
+    if (cppiaClassExt == null) cppiaClassExt = DefineUtil.getDefineStringArray('POLYMOD_CPPIA_CLASS_EXT', ['.cppia']);
+    return cppiaClassExt;
+  }
+
+  /**
    * The asset library to use for loading scripts.
    * Only relevant for Lime/OpenFL projects which use multiple asset libraries.
    *

--- a/polymod/backends/PolymodAssetLibrary.hx
+++ b/polymod/backends/PolymodAssetLibrary.hx
@@ -953,6 +953,8 @@ class PolymodAssetLibrary
     extensionSet('vdf', TEXT);
     extensionSet('xml', TEXT);
 
+    extensionSet('cppia', BYTES);
+
     extensionSet('avi', VIDEO);
     extensionSet('mkv', VIDEO);
     extensionSet('mov', VIDEO);

--- a/polymod/hscript/PolymodScriptBridge.hx
+++ b/polymod/hscript/PolymodScriptBridge.hx
@@ -1,0 +1,129 @@
+package polymod.hscript;
+
+import polymod.Polymod;
+import polymod.hscript._internal.PolymodAbstractScriptClass;
+import polymod.hscript._internal.PolymodScriptClass;
+import polymod.hscript._internal.PolymodStaticClassReference;
+
+/**
+ * Provides a bridge for interacting with script classes and their instances.
+ */
+class PolymodScriptBridge
+{
+  public static function findScript(asc:Dynamic, funcName:String):Dynamic
+  {
+    var cls:Dynamic = asc;
+
+    while (cls != null && cls is PolymodScriptClass)
+    {
+      var scriptCls:PolymodScriptClass = cast cls;
+      if (scriptCls.hasScriptFunction(funcName)) return scriptCls;
+
+      cls = scriptCls.superClass;
+    }
+
+    return null;
+  }
+
+  public static function callOn(scriptCls:Dynamic, funcName:String, funcArgs:Array<Dynamic>):Dynamic
+  {
+    if (scriptCls == null) return null;
+
+    var script:PolymodScriptClass = cast scriptCls;
+    return script.callFunction(funcName, funcArgs ?? []);
+  }
+
+  public static function fieldRead(asc:Dynamic, varName:String):Dynamic
+  {
+    if (asc == null) return null;
+
+    var script:PolymodAbstractScriptClass = cast asc;
+    return script.fieldRead(varName);
+  }
+
+  public static function fieldWrite(asc:Dynamic, varName:String, varValue:Dynamic):Dynamic
+  {
+    if (asc == null) return null;
+
+    var script:PolymodAbstractScriptClass = cast asc;
+    return script.fieldWrite(varName, varValue);
+  }
+
+  public static function fieldExists(asc:Dynamic, fieldName:String):Bool
+  {
+    if (asc == null) return false;
+
+    var script:PolymodAbstractScriptClass = cast asc;
+    return script.fieldExists(fieldName);
+  }
+
+  public static function callFunction(asc:Dynamic, funcName:String, funcArgs:Array<Dynamic>):Dynamic
+  {
+    if (asc == null) return null;
+
+    var script:PolymodAbstractScriptClass = cast asc;
+    return script.callFunction(funcName, funcArgs ?? []);
+  }
+
+  public static function listExtending(clsPath:String):Array<String>
+  {
+    return PolymodScriptClass.listScriptClassesExtending(clsPath);
+  }
+
+  public static function instantiate(clsName:String, underlyingClass:String, args:Array<Dynamic>):Dynamic
+  {
+    var clsRef:Null<PolymodStaticClassReference> = PolymodStaticClassReference.tryBuild(clsName);
+
+    if (clsRef == null)
+    {
+      Polymod.error(SCRIPT_RUNTIME_EXCEPTION,
+        'Could not construct instance of scripted class (${clsName} extends ${underlyingClass})\nUnknown error building class reference', SCRIPT_RUNTIME);
+      return null;
+    }
+
+    try
+    {
+      var result:Dynamic = clsRef.instantiate(args ?? []);
+
+      if (result == null)
+      {
+        Polymod.error(SCRIPT_RUNTIME_EXCEPTION,
+          'Could not construct instance of scripted class (${clsName} extends ${underlyingClass}):\nUnknown error instantiating class', SCRIPT_RUNTIME);
+        return null;
+      }
+
+      return result;
+    }
+    catch (error)
+    {
+      Polymod.error(SCRIPT_RUNTIME_EXCEPTION,
+        'Could not construct instance of scripted class (${clsName} extends ${underlyingClass}):\n${error}', SCRIPT_RUNTIME);
+      return null;
+    }
+  }
+
+  public static function staticGet(clsName:String, fieldName:String):Dynamic
+  {
+    return PolymodScriptClass.getScriptClassStaticField(clsName, fieldName);
+  }
+
+  public static function staticSet(clsName:String, fieldName:String, fieldValue:Dynamic):Dynamic
+  {
+    return PolymodScriptClass.setScriptClassStaticField(clsName, fieldName, fieldValue);
+  }
+
+  public static function staticHas(clsName:String, fieldName:String):Bool
+  {
+    return PolymodScriptClass.hasScriptClassStaticField(clsName, fieldName);
+  }
+
+  public static function staticHasFunc(clsName:String, fieldName:String):Bool
+  {
+    return PolymodScriptClass.hasScriptClassStaticFunction(clsName, fieldName);
+  }
+
+  public static function staticCall(clsName:String, funcName:String, funcArgs:Array<Dynamic>):Dynamic
+  {
+    return PolymodScriptClass.callScriptClassStaticFunction(clsName, funcName, funcArgs ?? []);
+  }
+}

--- a/polymod/hscript/_internal/Interp.hx
+++ b/polymod/hscript/_internal/Interp.hx
@@ -2457,7 +2457,7 @@ class Interp
     // If not, check if it is a blacklisted instance field.
     if (oCls.length > 0 && oCls != 'Object')
     {
-      if (PolymodScriptClass.blacklistedInstanceFields.exists(oCls) && PolymodScriptClass.blacklistedInstanceFields.get(oCls).contains(f))
+      if (PolymodScriptClass.blacklistedInstanceFieldsOf(oCls).contains(f))
       {
         error(EBlacklistedField(f));
         return null;
@@ -2573,7 +2573,7 @@ class Interp
     // If not, check if it is a blacklisted instance field.
     if (oCls.length > 0 && oCls != 'Object')
     {
-      if (PolymodScriptClass.blacklistedInstanceFields.exists(oCls) && PolymodScriptClass.blacklistedInstanceFields.get(oCls).contains(f))
+      if (PolymodScriptClass.blacklistedInstanceFieldsOf(oCls).contains(f))
       {
         Polymod.error(SCRIPTED_CLASS_BLACKLISTED_FIELD, 'Class field ${oCls}.${f} is blacklisted and cannot be used in scripts.', SCRIPT_RUNTIME);
         return null;

--- a/polymod/hscript/_internal/Interp.hx
+++ b/polymod/hscript/_internal/Interp.hx
@@ -2901,11 +2901,16 @@ class Interp
           continue;
         }
 
-        Polymod.error(
-          SCRIPTED_CLASS_UNRESOLVED_IMPORT,
-          'Could not import ${imp.fullPath}. Check to ensure the module exists and is spelled correctly.',
-          SCRIPT_RUNTIME
-        );
+        #if POLYMOD_CPPIA
+        // A compiled class has no descriptor, so check the cppia registry too.
+        if (PolymodCppiaClassReference.hasCppiaClass(imp.fullPath))
+        {
+          cls.imports.set(key, imp);
+          continue;
+        }
+        #end
+
+        Polymod.error(SCRIPTED_CLASS_UNRESOLVED_IMPORT, 'Could not import ${imp.fullPath}. Check to ensure the module exists and is spelled correctly.', SCRIPT_RUNTIME);
       }
 
       // Add the scripted usings.

--- a/polymod/hscript/_internal/Interp.hx
+++ b/polymod/hscript/_internal/Interp.hx
@@ -915,7 +915,7 @@ class Interp
         }
 
         // Fallback to field set
-        v = set(expr(e0), id, v);
+        v = set(fieldTarget(e0), id, v);
       case EArray(e, index):
         var arr:Dynamic = expr(e);
         var index:Dynamic = expr(index);
@@ -998,7 +998,7 @@ class Interp
         else
           l.r = v;
       case EField(e, f):
-        var obj = expr(e);
+        var obj = fieldTarget(e);
         v = fop(get(obj, f), expr(e2));
         v = set(obj, f, v);
       case EArray(e, index):
@@ -1079,7 +1079,7 @@ class Interp
           l.r = v + delta;
         return v;
       case EField(e, f):
-        var obj = expr(e);
+        var obj = fieldTarget(e);
         var v:Dynamic = get(obj, f);
         if (prefix)
         {
@@ -1537,7 +1537,8 @@ class Interp
         {
           return new PolymodEnum(_scriptEnumDescriptors.get(name), f, []);
         }
-        return get(expr(e), f);
+
+        return get(fieldTarget(e), f);
       case EBinop(op, e1, e2):
         var fop = binops.get(op);
         if (fop == null) error(EInvalidOp(op));
@@ -1593,7 +1594,7 @@ class Interp
         switch (Tools.expr(e))
         {
           case EField(e, f):
-            var obj = expr(e);
+            var obj = fieldTarget(e);
             if (obj == null) error(ENullObjectReference(f));
             return fcall(obj, f, args);
           default:
@@ -2164,6 +2165,72 @@ class Interp
     var a = new Array();
     for (e in entries) a.push(expr(e));
     return a;
+  }
+
+  /**
+   * The dotted path an expression spells out, if it is nothing but identifiers.
+   */
+  function dottedPath(e:Expr):Null<String>
+  {
+    switch (Tools.expr(e))
+    {
+      case EIdent(id):
+        return id;
+      case EField(sub, field):
+        var head:Null<String> = dottedPath(sub);
+        return head == null ? null : '$head.$field';
+      default:
+        return null;
+    }
+  }
+
+  /**
+   * The object a field access reads from, allowing for a type written out in full.
+   */
+  function fieldTarget(e:Expr):Dynamic
+  {
+    try
+    {
+      return expr(e);
+    }
+    catch (err:Expr.Error)
+    {
+      var path:Null<String> = dottedPath(e);
+      if (path == null) throw err;
+
+      var type:Null<Dynamic> = resolveDottedPath(path);
+      if (type == null) throw err;
+
+      return type;
+    }
+  }
+
+  /**
+   * A type named by its full path rather than imported first.
+   * The blacklist applies exactly as it does to an import.
+   */
+  function resolveDottedPath(path:String):Null<Dynamic>
+  {
+    if (PolymodScriptClass.importOverrides.exists(path))
+    {
+      var alias:Null<Class<Dynamic>> = PolymodScriptClass.importOverrides.get(path);
+      if (alias == null) error(EBlacklistedModule(path));
+      return alias;
+    }
+
+    if (PolymodScriptClass.abstractClassImpls.exists(path)) return PolymodScriptClass.abstractClassImpls.get(path);
+    if (PolymodScriptClass.typedefs.exists(path)) return PolymodScriptClass.typedefs.get(path);
+
+    var scripted = PolymodStaticClassReference.tryBuild(path);
+    if (scripted != null) return scripted;
+
+    var cls:Null<Class<Dynamic>> = Type.resolveClass(path);
+    #if POLYMOD_CPPIA
+    if (cls != null && PolymodCppiaClassReference.isInactiveCppiaClass(path)) cls = null;
+    #end
+    if (cls != null) return cls;
+
+    return Type.resolveEnum(path);
   }
 
   function getIdent(e:Expr):Null<String>

--- a/polymod/hscript/_internal/Interp.hx
+++ b/polymod/hscript/_internal/Interp.hx
@@ -1410,6 +1410,9 @@ class Interp
       else
       {
         var resultCls:Class<Dynamic> = Type.resolveClass(fullPath);
+        #if POLYMOD_CPPIA
+        if (resultCls != null && PolymodCppiaClassReference.isInactiveCppiaClass(fullPath)) resultCls = null;
+        #end
         if (resultCls != null)
         {
           importedClass.cls = resultCls;

--- a/polymod/hscript/_internal/PolymodBaseClassMacro.hx
+++ b/polymod/hscript/_internal/PolymodBaseClassMacro.hx
@@ -84,6 +84,8 @@ class PolymodBaseClassMacro
     var fullClsName:String = formatClassString(cls);
     if (fullClsName.indexOf('polymod.') == 0) return fields; // Disallow extending polymod classes.
 
+    if (Context.defined('cppia') && !isHostClass(fullClsName)) return fields;
+
     // Check if a class already has one of the fields needed for the scripts before attempting to build fields.
     // We only need to check (and add) instance fields if a class doesn't extend anything, considering extending classes inherit them.
     var neededStaticFields:Array<String> = [
@@ -694,6 +696,35 @@ class PolymodBaseClassMacro
    * to only have a single return, however due to how script extending works, this is no longer a guarantee.
    * @param fields  The fields whose function expressions to check and modify.
    */
+  /**
+   * The classes the host binary already carries, read from the `dll_import` file hxcpp is given.
+   */
+  static var hostClasses:Null<Map<String, Bool>> = null;
+
+  /**
+   * Whether this class lives in the host rather than in the module being compiled.
+   */
+  static function isHostClass(clsName:String):Bool
+  {
+    if (hostClasses == null)
+    {
+      hostClasses = new Map<String, Bool>();
+
+      var path:Null<String> = Context.definedValue('dll_import');
+
+      if (path != null && sys.FileSystem.exists(path))
+      {
+        for (line in sys.io.File.getContent(path).split('\n'))
+        {
+          var trimmed:String = StringTools.trim(line);
+          if (StringTools.startsWith(trimmed, 'class ')) hostClasses.set(StringTools.trim(trimmed.substr(6)), true);
+        }
+      }
+    }
+
+    return hostClasses.exists(clsName);
+  }
+
   static function removeInlinedFunctionCalls(fields:Array<Field>):Void
   {
     // This is a heavy operation and isn't needed to be done during code completion.

--- a/polymod/hscript/_internal/PolymodBaseClassMacro.hx
+++ b/polymod/hscript/_internal/PolymodBaseClassMacro.hx
@@ -24,6 +24,17 @@ class PolymodBaseClassMacro
    */
   public static final PROCESS_FINISHED_META:String = ':hscriptBaseCreated';
 
+  /**
+   * A metadata a compiled script puts on one of its own classes to have these fields built for it.
+   * That is what lets an hscript class extend a class a compiled script declares.
+   */
+  public static final CPPIA_EXTENDABLE_META:String = ':hscriptExtendable';
+
+  static function useBridge():Bool
+  {
+    return Context.defined('cppia');
+  }
+
   public static function buildBaseClass():Array<Field>
   {
     var cls:ClassType = null;
@@ -84,7 +95,7 @@ class PolymodBaseClassMacro
     var fullClsName:String = formatClassString(cls);
     if (fullClsName.indexOf('polymod.') == 0) return fields; // Disallow extending polymod classes.
 
-    if (Context.defined('cppia') && !isHostClass(fullClsName)) return fields;
+    if (Context.defined('cppia') && !isHostClass(fullClsName) && !cls.meta.has(CPPIA_EXTENDABLE_META)) return fields;
 
     // Check if a class already has one of the fields needed for the scripts before attempting to build fields.
     // We only need to check (and add) instance fields if a class doesn't extend anything, considering extending classes inherit them.
@@ -218,7 +229,24 @@ class PolymodBaseClassMacro
           }
 
           var oldPos:haxe.macro.Expr.Position = f.expr.pos;
-          f.expr = macro
+          f.expr = useBridge() ? (macro
+            {
+              if (_asc != null && !_skipAscFrom.contains($v{fields[i].name}))
+              {
+                var scriptCls:Dynamic = polymod.hscript.PolymodScriptBridge.findScript(_asc, $v{fields[i].name});
+                if (scriptCls != null) $
+                {
+                  doesReturnVoid ? (macro
+                    {
+                      polymod.hscript.PolymodScriptBridge.callOn(scriptCls, $v{fields[i].name}, [$a{argExprs}]);
+                      return;
+                    }) : (macro return cast polymod.hscript.PolymodScriptBridge.callOn(scriptCls, $v{fields[i].name}, [$a{argExprs}]))
+                }
+              }
+
+              // Fallback, call the original function.
+              ${f.expr}
+            }) : (macro
             {
               if (_asc != null && !_skipAscFrom.contains($v{fields[i].name}))
               {
@@ -241,7 +269,7 @@ class PolymodBaseClassMacro
 
               // Fallback, call the original function.
               ${f.expr}
-            };
+            });
 
           f.expr.pos = oldPos;
 
@@ -276,7 +304,7 @@ class PolymodBaseClassMacro
           pos: buildPos
         }
       ],
-      kind: FieldType.FVar(macro :Null<polymod.hscript._internal.PolymodAbstractScriptClass>),
+      kind: FieldType.FVar(useBridge() ? (macro :Null<Dynamic>) : (macro :Null<polymod.hscript._internal.PolymodAbstractScriptClass>)),
       pos: buildPos,
     };
 
@@ -310,10 +338,13 @@ class PolymodBaseClassMacro
           type: macro :String
         }],
         ret: macro :Dynamic,
-        expr: macro
+        expr: useBridge() ? (macro
+        {
+          return polymod.hscript.PolymodScriptBridge.fieldRead(_asc, varName);
+        }) : (macro
         {
           return _asc?.fieldRead(varName);
-        },
+        }),
       }),
     };
 
@@ -336,10 +367,13 @@ class PolymodBaseClassMacro
           }
         ],
         ret: macro :Dynamic,
-        expr: macro
+        expr: useBridge() ? (macro
+        {
+          return polymod.hscript.PolymodScriptBridge.fieldWrite(_asc, varName, varValue);
+        }) : (macro
         {
           return _asc?.fieldWrite(varName, varValue);
-        },
+        }),
       })
     };
 
@@ -355,10 +389,13 @@ class PolymodBaseClassMacro
           type: macro :String
         }],
         ret: macro :Bool,
-        expr: macro
+        expr: useBridge() ? (macro
+        {
+          return polymod.hscript.PolymodScriptBridge.fieldExists(_asc, fieldName);
+        }) : (macro
         {
           return _asc?.fieldExists(fieldName) ?? false;
-        },
+        }),
       }),
     };
 
@@ -381,10 +418,13 @@ class PolymodBaseClassMacro
           }
         ],
         ret: macro :Dynamic,
-        expr: macro
+        expr: useBridge() ? (macro
+        {
+          return polymod.hscript.PolymodScriptBridge.callFunction(_asc, funcName, funcArgs ?? []);
+        }) : (macro
         {
           return _asc?.callFunction(funcName, funcArgs ?? []);
-        },
+        }),
       }),
     };
 
@@ -476,10 +516,13 @@ class PolymodBaseClassMacro
       kind: FFun({
         args: [],
         ret: macro :Array<String>,
-        expr: macro
+        expr: useBridge() ? (macro
+        {
+          return polymod.hscript.PolymodScriptBridge.listExtending($v{underlyingClass});
+        }) : (macro
         {
           return polymod.hscript._internal.PolymodScriptClass.listScriptClassesExtending($v{underlyingClass});
-        },
+        }),
       }),
     };
 
@@ -502,7 +545,12 @@ class PolymodBaseClassMacro
           }
         ],
         ret: macro :Null<$complexType>,
-        expr: macro
+        expr: useBridge() ? (macro
+        {
+          // The whole of this lives in the bridge, so a script names neither the class
+          // reference nor the error reporter.
+          return cast polymod.hscript.PolymodScriptBridge.instantiate(clsName, $v{underlyingClass}, (cast args) ?? []);
+        }) : (macro
         {
           var clsRef = polymod.hscript._internal.PolymodStaticClassReference.tryBuild(clsName);
 
@@ -540,7 +588,7 @@ class PolymodBaseClassMacro
             );
             return null;
           }
-        },
+        }),
       }),
     }
 
@@ -562,10 +610,13 @@ class PolymodBaseClassMacro
           },
         ],
         ret: macro :Dynamic,
-        expr: macro
+        expr: useBridge() ? (macro
+        {
+          return polymod.hscript.PolymodScriptBridge.staticGet(clsName, fieldName);
+        }) : (macro
         {
           return polymod.hscript._internal.PolymodScriptClass.getScriptClassStaticField(clsName, fieldName);
-        }
+        })
       })
     };
 
@@ -592,10 +643,13 @@ class PolymodBaseClassMacro
           },
         ],
         ret: macro :Dynamic,
-        expr: macro
+        expr: useBridge() ? (macro
+        {
+          return polymod.hscript.PolymodScriptBridge.staticSet(clsName, fieldName, fieldValue);
+        }) : (macro
         {
           return polymod.hscript._internal.PolymodScriptClass.setScriptClassStaticField(clsName, fieldName, fieldValue);
-        }
+        })
       })
     };
 
@@ -617,10 +671,13 @@ class PolymodBaseClassMacro
           }
         ],
         ret: macro :Bool,
-        expr: macro
+        expr: useBridge() ? (macro
+        {
+          return polymod.hscript.PolymodScriptBridge.staticHas(clsName, fieldName);
+        }) : (macro
         {
           return polymod.hscript._internal.PolymodScriptClass.hasScriptClassStaticField(clsName, fieldName);
-        },
+        }),
       }),
     };
 
@@ -642,10 +699,13 @@ class PolymodBaseClassMacro
           }
         ],
         ret: macro :Bool,
-        expr: macro
+        expr: useBridge() ? (macro
+        {
+          return polymod.hscript.PolymodScriptBridge.staticHasFunc(clsName, fieldName);
+        }) : (macro
         {
           return polymod.hscript._internal.PolymodScriptClass.hasScriptClassStaticFunction(clsName, fieldName);
-        },
+        }),
       }),
     };
 
@@ -672,10 +732,13 @@ class PolymodBaseClassMacro
           }
         ],
         ret: macro :Dynamic,
-        expr: macro
+        expr: useBridge() ? (macro
+        {
+          return polymod.hscript.PolymodScriptBridge.staticCall(clsName, funcName, funcArgs ?? []);
+        }) : (macro
         {
           return polymod.hscript._internal.PolymodScriptClass.callScriptClassStaticFunction(clsName, funcName, funcArgs ?? []);
-        }
+        })
       })
     };
 

--- a/polymod/hscript/_internal/PolymodCPPIATarget.hx
+++ b/polymod/hscript/_internal/PolymodCPPIATarget.hx
@@ -1,0 +1,107 @@
+package polymod.hscript._internal;
+
+/**
+ * Picks which compiled scripts belong to the platform the game is running on.
+ * Supports desktop platforms (windows, macos, linux), mobile platforms (android, ios).
+ * Also two generic tags, 'desktop' and 'mobile', which cover all desktop and mobile platforms respectively.
+ *
+ * Also falls back to regular .cppia files when no platform-specific one is available.
+ */
+class PolymodCppiaTarget
+{
+  /**
+   * Every tag that names a platform rather than being part of a file name.
+   */
+  public static final KNOWN_TAGS:Array<String> = [
+    'windows', 'macos', 'mac', 'linux', 'android', 'ios', 'switch', 'desktop', 'mobile'
+  ];
+
+  /**
+   * The tags that fit the current platform, closest first.
+   */
+  public static var tags(get, default):Array<String>;
+
+  static function get_tags():Array<String>
+  {
+    if (tags == null) tags = detect();
+    return tags;
+  }
+
+  static function detect():Array<String>
+  {
+    #if android
+    return ['android', 'mobile'];
+    #elseif ios
+    return ['ios', 'mobile'];
+    #elseif windows
+    return ['windows', 'desktop'];
+    #elseif mac
+    return ['macos', 'mac', 'desktop'];
+    #elseif linux
+    return ['linux', 'desktop'];
+    #else
+    return [];
+    #end
+  }
+
+  /**
+   * Keeps one compiled script per name, the one that fits this platform best.
+   */
+  public static function select(paths:Array<String>):Array<String>
+  {
+    var best:Map<String, String> = new Map<String, String>();
+    var scores:Map<String, Int> = new Map<String, Int>();
+    var order:Array<String> = [];
+
+    for (path in paths)
+    {
+      var parts = split(path);
+      var score:Int = rank(parts.tag);
+      if (score < 0) continue;
+
+      if (!best.exists(parts.base))
+      {
+        order.push(parts.base);
+      }
+      else if (score >= scores.get(parts.base))
+      {
+        continue;
+      }
+
+      best.set(parts.base, path);
+      scores.set(parts.base, score);
+    }
+
+    return [for (base in order) best.get(base)];
+  }
+
+  /**
+   * How closely a tag fits this platform. Lower is closer, -1 means it does not fit at all.
+   */
+  public static function rank(tag:Null<String>):Int
+  {
+    if (tag == null) return tags.length;
+    return tags.indexOf(tag);
+  }
+
+  /**
+   * Splits a path into the name it shares with its other platforms, and the tag it carried.
+   */
+  public static function split(path:String):{base:String, tag:Null<String>}
+  {
+    var ext:String = '';
+    for (candidate in PolymodConfig.cppiaClassExt)
+    {
+      if (path.length > candidate.length && StringTools.endsWith(path, candidate) && candidate.length > ext.length) ext = candidate;
+    }
+
+    var stem:String = path.substr(0, path.length - ext.length);
+    var dot:Int = stem.lastIndexOf('.');
+    if (dot <= 0 || dot < stem.lastIndexOf('/') || dot < stem.lastIndexOf('\\')) return {base: path, tag: null};
+
+    var tag:String = stem.substr(dot + 1).toLowerCase();
+    if (KNOWN_TAGS.indexOf(tag) == -1) return {base: path, tag: null};
+
+    return {base: stem.substr(0, dot) + ext, tag: tag};
+  }
+}

--- a/polymod/hscript/_internal/PolymodCPPIATarget.hx
+++ b/polymod/hscript/_internal/PolymodCPPIATarget.hx
@@ -7,7 +7,7 @@ package polymod.hscript._internal;
  *
  * Also falls back to regular .cppia files when no platform-specific one is available.
  */
-class PolymodCppiaTarget
+class PolymodCPPIATarget
 {
   /**
    * Every tag that names a platform rather than being part of a file name.

--- a/polymod/hscript/_internal/PolymodCppiaClassReference.hx
+++ b/polymod/hscript/_internal/PolymodCppiaClassReference.hx
@@ -20,6 +20,27 @@ class PolymodCppiaClassReference extends PolymodStaticClassReference
   static final everProvided:Map<String, Bool> = new Map<String, Bool>();
 
   /**
+   * Every class a compiled script declared, including the ones it did not put in its manifest.
+   */
+  static final declared:Map<String, Class<Dynamic>> = new Map<String, Class<Dynamic>>();
+
+  /**
+   * Whether this class name came out of a compiled script rather than the game.
+   */
+  public static function isScriptClass(clsName:String):Bool
+  {
+    return declared.exists(clsName);
+  }
+
+  /**
+   * The class a compiled script declared under this name, if any.
+   */
+  public static function resolveScriptClass(clsName:String):Null<Class<Dynamic>>
+  {
+    return declared.get(clsName);
+  }
+
+  /**
    * The version a cppia must be stamped with to be accepted.
    */
   public static var expectedVersion:Null<String> = null;
@@ -172,20 +193,8 @@ class PolymodCppiaClassReference extends PolymodStaticClassReference
    * Check a compiled script against the blacklist before any of it runs.
    * @return The denied names it references, or null if the file could not be read at all.
    */
-  static function scanDenied(data:haxe.io.Bytes, path:String):Null<Array<String>>
+  static function scanDenied(types:Array<String>):Array<String>
   {
-    var types:Array<String> = null;
-
-    try
-    {
-      types = PolymodCppiaScanner.readTypes(data);
-    }
-    catch (e:Dynamic)
-    {
-      Polymod.error(SCRIPT_PARSE_FAILED, 'Could not read the header of compiled script "$path": $e', SCRIPT_RUNTIME);
-      return null;
-    }
-
     var denied:Map<String, Bool> = deniedNames();
     var found:Array<String> = [];
 
@@ -243,8 +252,19 @@ class PolymodCppiaClassReference extends PolymodStaticClassReference
       loadedModules.remove(path);
     }
 
-    var denied:Null<Array<String>> = scanDenied(data, path);
-    if (denied == null) return [];
+    var types:Array<String> = null;
+
+    try
+    {
+      types = PolymodCppiaScanner.readTypes(data);
+    }
+    catch (e:Dynamic)
+    {
+      Polymod.error(SCRIPT_PARSE_FAILED, 'Could not read the header of compiled script "$path": $e', SCRIPT_RUNTIME);
+      return [];
+    }
+
+    var denied:Array<String> = scanDenied(types);
 
     if (denied.length > 0)
     {
@@ -284,6 +304,24 @@ class PolymodCppiaClassReference extends PolymodStaticClassReference
     {
       Polymod.error(SCRIPT_PARSE_FAILED, 'Failed to boot compiled script "$path": $e', SCRIPT_RUNTIME);
       return [];
+    }
+
+    var moduleClasses:Array<String> = [];
+
+    for (type in types)
+    {
+      var cls:Null<Class<Dynamic>> = null;
+
+      try
+      {
+        cls = module.resolveClass(type);
+      }
+      catch (e:Dynamic) {}
+
+      if (cls == null) continue;
+
+      declared.set(type, cls);
+      moduleClasses.push(type);
     }
 
     var manifest:Class<Dynamic> = null;
@@ -358,7 +396,7 @@ class PolymodCppiaClassReference extends PolymodStaticClassReference
 
     loadedModules.set(path, new LoadedCppiaModule(signature, registered, registeredRefs, module));
 
-    trace('[cppia] loaded "$path" providing ${registered.join(", ")}');
+    trace('[cppia] loaded "$path" providing ${registered.join(", ")}, declaring ${moduleClasses.join(", ")}');
 
     return registered;
     #else

--- a/polymod/hscript/_internal/PolymodCppiaClassReference.hx
+++ b/polymod/hscript/_internal/PolymodCppiaClassReference.hx
@@ -68,6 +68,14 @@ class PolymodCppiaClassReference extends PolymodStaticClassReference
   }
 
   /**
+   * The class a loaded compiled script is providing under this name, if any.
+   */
+  public static function getCppiaClass(clsName:String):Null<Class<Dynamic>>
+  {
+    return registry.get(clsName);
+  }
+
+  /**
    * Whether this name belongs to a compiled script that is no longer loaded.
    *
    * The class object still exists, because hxcpp cannot unload it, but nothing should resolve to it.

--- a/polymod/hscript/_internal/PolymodCppiaClassReference.hx
+++ b/polymod/hscript/_internal/PolymodCppiaClassReference.hx
@@ -1,5 +1,7 @@
 package polymod.hscript._internal;
 
+import polymod.hscript._internal.PolymodCppiaScanner.CppiaScan;
+
 /**
  * A class reference backed by a compiled cppia class instead of a parsed script.
  */
@@ -59,7 +61,7 @@ class PolymodCppiaClassReference extends PolymodStaticClassReference
    */
   static function signatureOf(data:haxe.io.Bytes):String
   {
-    return '${data.length}:${haxe.crypto.Crc32.make(data)}';
+    return '${data.length}:${haxe.crypto.Crc32.make(data)}:${PolymodScriptClass.blacklistGeneration}';
   }
 
   public static function hasCppiaClass(clsName:String):Bool
@@ -215,6 +217,228 @@ class PolymodCppiaClassReference extends PolymodStaticClassReference
     return found;
   }
 
+  /**
+   * The hxcpp builtins a compiled script may call, mapped to the only argument count that is safe.
+   */
+  static final ALLOWED_GLOBALS:Map<String, Int> = [
+    '__hxcpp_memory_get_byte' => 2,
+    '__hxcpp_memory_set_byte' => 3,
+    '__hxcpp_memory_get_i32' => 2,
+    '__hxcpp_memory_set_i32' => 3,
+    '__hxcpp_memory_get_ui32' => 2,
+    '__hxcpp_memory_set_ui32' => 3,
+    '__hxcpp_memory_get_i16' => 2,
+    '__hxcpp_memory_set_i16' => 3,
+    '__hxcpp_memory_get_ui16' => 2,
+    '__hxcpp_memory_set_ui16' => 3,
+    '__hxcpp_memory_get_float' => 2,
+    '__hxcpp_memory_set_float' => 3,
+    '__hxcpp_memory_get_double' => 2,
+    '__hxcpp_memory_set_double' => 3,
+    '__hxcpp_thread_create' => 1,
+    '__hxcpp_thread_send' => 2
+  ];
+
+  /**
+   * Turn a name out of a compiled script's type table into one the game can compare.
+   */
+  static function normalizeTypeName(raw:String):String
+  {
+    if (raw == null) return '';
+
+    var name:String = StringTools.replace(raw, '::', '.');
+
+    while (name.length > 0 && name.charAt(0) == '.')
+      name = name.substr(1);
+
+    // A parameterised array is written with its element type, as `Array.String` and the like.
+    if (StringTools.startsWith(name, 'Array.')) name = 'Array';
+
+    return name;
+  }
+
+  /**
+   * The name a type table entry refers to, empty if it is Dynamic or out of range.
+   */
+  static function nameOfType(typeId:Int, scan:CppiaScan):String
+  {
+    if (typeId < 0 || typeId >= scan.types.length) return '';
+    return normalizeTypeName(scan.types[typeId]);
+  }
+
+  /**
+   * Every class name a value of this type could be blacklisted under.
+   */
+  static function ancestryOf(typeId:Int, scan:CppiaScan, cache:Map<Int, Array<String>>):Array<String>
+  {
+    var cached:Null<Array<String>> = cache.get(typeId);
+    if (cached != null) return cached;
+
+    var result:Array<String> = [];
+    var seen:Map<Int, Bool> = new Map<Int, Bool>();
+    var id:Int = typeId;
+
+    var depth:Int = 0;
+
+    // Classes this module declares itself, which nothing can resolve until it has booted.
+    while (scan.ancestry.exists(id) && !seen.exists(id) && depth++ < 64)
+    {
+      seen.set(id, true);
+
+      var related:Array<Int> = scan.ancestry.get(id);
+      result.push(nameOfType(id, scan));
+
+      for (i in 1...related.length)
+        result.push(nameOfType(related[i], scan));
+
+      id = related[0];
+      if (id <= 0)
+      {
+        cache.set(typeId, result);
+        return result;
+      }
+    }
+
+    // Past that, the rest of the chain is game classes, which can be resolved the usual way.
+    var name:String = nameOfType(id, scan);
+
+    if (name.length == 0)
+    {
+      cache.set(typeId, result);
+      return result;
+    }
+
+    result.push(name);
+
+    var cls:Null<Class<Dynamic>> = null;
+    try
+    {
+      cls = Type.resolveClass(name);
+    }
+    catch (_:Dynamic) {}
+
+    while (cls != null && depth++ < 64)
+    {
+      try
+      {
+        cls = Type.getSuperClass(cls);
+      }
+      catch (_:Dynamic)
+      {
+        break;
+      }
+
+      if (cls == null) break;
+
+      var resolved:Null<String> = Type.getClassName(cls);
+      if (resolved == null || result.contains(resolved)) break;
+
+      result.push(resolved);
+    }
+
+    cache.set(typeId, result);
+    return result;
+  }
+
+  /**
+   * Where in the mod's own source a reference came from, if the script was built with that in it.
+   */
+  static function siteOf(fileId:Int, line:Int, scan:CppiaScan):String
+  {
+    if (fileId <= 0 || fileId >= scan.strings.length) return '';
+
+    var file:String = scan.strings[fileId];
+    if (file.length == 0) return '';
+
+    return ' ($file:$line)';
+  }
+
+  /**
+   * Check the fields a compiled script names against the blacklist, before any of it runs.
+   * @return The fields it may not use, described for a person to read.
+   */
+  static function scanDeniedFields(scan:CppiaScan):Array<String>
+  {
+    var found:Array<String> = [];
+    var cache:Map<Int, Array<String>> = new Map<Int, Array<String>>();
+
+    var i:Int = 0;
+
+    while (i + 1 < scan.fieldRefs.length)
+    {
+      var classId:Int = scan.fieldRefs[i];
+      var fieldId:Int = scan.fieldRefs[i + 1];
+      var fileId:Int = scan.fieldSites[i];
+      var line:Int = scan.fieldSites[i + 1];
+      i += 2;
+
+      if (fieldId < 0 || fieldId >= scan.strings.length) continue;
+
+      var field:String = scan.strings[fieldId];
+      if (field.length == 0) continue;
+
+      var where:String = siteOf(fileId, line, scan);
+
+      var owner:String = nameOfType(classId, scan);
+
+      // A receiver whose type was not known hides which class the field belongs to, so only the names singled out as
+      // unreachable by any route apply here. That is written either as the empty type or as a type literally named
+      // Dynamic, depending on how the value lost its type, so both mean the same thing.
+      if (owner.length == 0 || owner == 'Dynamic')
+      {
+        if (PolymodScriptClass.blacklistedDynamicFieldNames.exists(field))
+        {
+          var entry:String = '$field$where';
+          if (!found.contains(entry)) found.push(entry);
+        }
+
+        continue;
+      }
+
+      for (name in ancestryOf(classId, scan, cache))
+      {
+        if (name.length == 0) continue;
+        if (!PolymodScriptClass.isBlacklistedFieldExact(name, field)) continue;
+
+        var entry:String = '$name.$field$where';
+        if (!found.contains(entry)) found.push(entry);
+        break;
+      }
+    }
+
+    return found;
+  }
+
+  /**
+   * Check the hxcpp builtins a compiled script calls, before any of it runs.
+   * @return The calls it may not make, described for a person to read.
+   */
+  static function scanDeniedGlobals(scan:CppiaScan):Array<String>
+  {
+    var found:Array<String> = [];
+
+    var i:Int = 0;
+
+    while (i + 1 < scan.globalCalls.length)
+    {
+      var nameId:Int = scan.globalCalls[i];
+      var argCount:Int = scan.globalCalls[i + 1];
+      i += 2;
+
+      if (nameId < 0 || nameId >= scan.strings.length) continue;
+
+      var name:String = scan.strings[nameId];
+      if (!StringTools.startsWith(name, '__hxcpp_')) continue;
+
+      if (ALLOWED_GLOBALS.exists(name) && ALLOWED_GLOBALS.get(name) == argCount) continue;
+
+      var entry:String = '$name with $argCount argument(s)';
+      if (!found.contains(entry)) found.push(entry);
+    }
+
+    return found;
+  }
+
   public static function tryBuildCppia(clsName:String):Null<PolymodCppiaClassReference>
   {
     var cls = registry.get(clsName);
@@ -260,16 +484,40 @@ class PolymodCppiaClassReference extends PolymodStaticClassReference
       loadedModules.remove(path);
     }
 
-    var types:Array<String> = null;
+    var scan:CppiaScan = null;
 
     try
     {
-      types = PolymodCppiaScanner.readTypes(data);
+      scan = PolymodCppiaScanner.scan(data, PolymodScriptClass.blacklistedFieldNames(), true);
     }
     catch (e:Dynamic)
     {
       Polymod.error(SCRIPT_PARSE_FAILED, 'Could not read the header of compiled script "$path": $e', SCRIPT_RUNTIME);
       return [];
+    }
+
+    var types:Array<String> = scan.types;
+
+    // Cannot be CPPIB, which is the binary form of CPPIA. Harder to check.
+    if (scan.binary)
+    {
+      Polymod.error(SCRIPT_PARSE_FAILED,
+        'Compiled script "$path" is in the binary cppia format, which cannot be checked against the blacklist. Rebuild it with the current build command.',
+        SCRIPT_RUNTIME);
+      return [];
+    }
+
+    if (scan.suspect)
+    {
+      Polymod.error(SCRIPT_PARSE_FAILED, 'Compiled script "$path" is malformed and could not be checked. It will not be loaded.', SCRIPT_RUNTIME);
+      return [];
+    }
+
+    if (scan.unknownTokens.length > 0)
+    {
+      Polymod.warning(SCRIPT_PARSE_FAILED,
+        'Compiled script "$path" contains instructions this version does not know about: ${scan.unknownTokens.join(", ")}. It was still checked, but polymod may need updating for this version of hxcpp.',
+        SCRIPT_RUNTIME);
     }
 
     var denied:Array<String> = scanDenied(types);
@@ -278,6 +526,26 @@ class PolymodCppiaClassReference extends PolymodStaticClassReference
     {
       Polymod.error(SCRIPT_PARSE_FAILED,
         'Compiled script "$path" references ${denied.length == 1 ? "a class" : "classes"} that mods are not allowed to use: ${denied.join(", ")}. It will not be loaded.',
+        SCRIPT_RUNTIME);
+      return [];
+    }
+
+    var deniedFields:Array<String> = scanDeniedFields(scan);
+
+    if (deniedFields.length > 0)
+    {
+      Polymod.error(SCRIPT_PARSE_FAILED,
+        'Compiled script "$path" uses ${deniedFields.length == 1 ? "a class field" : "class fields"} that mods are not allowed to use: ${deniedFields.join(", ")}. It will not be loaded.',
+        SCRIPT_RUNTIME);
+      return [];
+    }
+
+    var deniedGlobals:Array<String> = scanDeniedGlobals(scan);
+
+    if (deniedGlobals.length > 0)
+    {
+      Polymod.error(SCRIPT_PARSE_FAILED,
+        'Compiled script "$path" uses raw memory access that mods are not allowed to use: ${deniedGlobals.join(", ")}. It will not be loaded.',
         SCRIPT_RUNTIME);
       return [];
     }
@@ -462,6 +730,12 @@ class PolymodCppiaClassReference extends PolymodStaticClassReference
       return null;
     }
 
+    if (PolymodScriptClass.isBlacklistedField(clsName, funcName))
+    {
+      Polymod.error(SCRIPTED_CLASS_BLACKLISTED_FIELD, 'Class field ${clsName}.${funcName} is blacklisted and cannot be used in scripts.', SCRIPT_RUNTIME);
+      return null;
+    }
+
     var fn:Dynamic = Reflect.field(cppiaClass, funcName);
     if (fn == null)
     {
@@ -495,6 +769,12 @@ class PolymodCppiaClassReference extends PolymodStaticClassReference
       return null;
     }
 
+    if (PolymodScriptClass.isBlacklistedField(clsName, fieldName))
+    {
+      Polymod.error(SCRIPTED_CLASS_BLACKLISTED_FIELD, 'Class field ${clsName}.${fieldName} is blacklisted and cannot be used in scripts.', SCRIPT_RUNTIME);
+      return null;
+    }
+
     return Reflect.field(cppiaClass, fieldName);
   }
 
@@ -503,6 +783,12 @@ class PolymodCppiaClassReference extends PolymodStaticClassReference
     if (cppiaClass == null)
     {
       Polymod.error(SCRIPT_RUNTIME_EXCEPTION, 'Compiled class ($clsName) is not loaded, so "$fieldName" cannot be written.', SCRIPT_RUNTIME);
+      return null;
+    }
+
+    if (PolymodScriptClass.isBlacklistedField(clsName, fieldName))
+    {
+      Polymod.error(SCRIPTED_CLASS_BLACKLISTED_FIELD, 'Class field ${clsName}.${fieldName} is blacklisted and cannot be used in scripts.', SCRIPT_RUNTIME);
       return null;
     }
 

--- a/polymod/hscript/_internal/PolymodCppiaClassReference.hx
+++ b/polymod/hscript/_internal/PolymodCppiaClassReference.hx
@@ -1,0 +1,200 @@
+package polymod.hscript._internal;
+
+/**
+ * A class reference backed by a compiled cppia class instead of a parsed script.
+ */
+class PolymodCppiaClassReference extends PolymodStaticClassReference
+{
+  public static final MANIFEST_CLASS:String = 'PolymodCppiaManifest';
+
+  static final registry:Map<String, Class<Dynamic>> = new Map<String, Class<Dynamic>>();
+
+  /**
+   * The version a cppia must be stamped with to be accepted.
+   */
+  public static var expectedVersion:Null<String> = null;
+
+  static var reportedMismatch:Bool = false;
+
+  public static function clearCppiaClasses():Void
+  {
+    registry.clear();
+    reportedMismatch = false;
+  }
+
+  public static function hasCppiaClass(clsName:String):Bool
+  {
+    return registry.exists(clsName);
+  }
+
+  public static function listCppiaClasses():Array<String>
+  {
+    return [for (name in registry.keys()) name];
+  }
+
+  /**
+   * A cppia class is a real class, so we can check its superclasses to see if it extends the given class path.
+   */
+  public static function listCppiaClassesExtending(clsPath:String):Array<String>
+  {
+    var result:Array<String> = [];
+
+    for (name => cls in registry)
+    {
+      var superCls = Type.getSuperClass(cls);
+      while (superCls != null)
+      {
+        if (Type.getClassName(superCls) == clsPath)
+        {
+          result.push(name);
+          break;
+        }
+        superCls = Type.getSuperClass(superCls);
+      }
+    }
+
+    return result;
+  }
+
+  public static function tryBuildCppia(clsName:String):Null<PolymodCppiaClassReference>
+  {
+    var cls = registry.get(clsName);
+    if (cls == null) return null;
+    return new PolymodCppiaClassReference(clsName, cls);
+  }
+
+  /**
+   * Load a compiled script and register the classes it declares.
+   * @return The names of the classes registered, empty if the module was refused.
+   */
+  public static function registerModule(data:haxe.io.Bytes, path:String):Array<String>
+  {
+    #if (hxcpp && POLYMOD_CPPIA)
+    var module:cpp.cppia.Module = null;
+
+    try
+    {
+      module = cpp.cppia.Module.fromData(data.getData());
+      module.boot();
+    }
+    catch (e:Dynamic)
+    {
+      Polymod.error(SCRIPT_PARSE_FAILED, 'Failed to load compiled script "$path": $e', SCRIPT_RUNTIME);
+      return [];
+    }
+
+    var manifest:Class<Dynamic> = null;
+    try
+    {
+      manifest = module.resolveClass(MANIFEST_CLASS);
+    }
+    catch (e:Dynamic)
+    {
+      manifest = null;
+    }
+
+    if (manifest == null)
+    {
+      Polymod.error(SCRIPT_PARSE_FAILED, 'Compiled script "$path" has no $MANIFEST_CLASS, rebuild it with the current build command.', SCRIPT_RUNTIME);
+      return [];
+    }
+
+    var stamp:String = Std.string(Reflect.field(manifest, 'gameVersion'));
+    if (expectedVersion != null && stamp != expectedVersion)
+    {
+      if (!reportedMismatch)
+      {
+        reportedMismatch = true;
+        Polymod.error(SCRIPT_PARSE_FAILED,
+          'Compiled script "$path" was built for game version "$stamp" but this game is "$expectedVersion". It will not be loaded, so the mod needs rebuilding.',
+          SCRIPT_RUNTIME);
+      }
+      return [];
+    }
+
+    var declared:Array<Class<Dynamic>> = cast Reflect.field(manifest, 'classRefs');
+    if (declared == null)
+    {
+      Polymod.error(SCRIPT_PARSE_FAILED, 'Compiled script "$path" has no classRefs, rebuild it with the current build command.', SCRIPT_RUNTIME);
+      return [];
+    }
+
+    var registered:Array<String> = [];
+    for (cls in declared)
+    {
+      if (cls == null) continue;
+
+      var name = Type.getClassName(cls);
+      if (name == null) continue;
+
+      registry.set(name, cls);
+      registered.push(name);
+    }
+
+    return registered;
+    #else
+    return [];
+    #end
+  }
+
+  final clsName:String;
+  final cppiaClass:Class<Dynamic>;
+
+  public function new(clsName:String, cppiaClass:Class<Dynamic>)
+  {
+    super();
+    this.clsName = clsName;
+    this.cppiaClass = cppiaClass;
+  }
+
+  override public function instantiate(?args:Array<Dynamic>):Null<Dynamic>
+  {
+    try
+    {
+      return Type.createInstance(cppiaClass, args ?? []);
+    }
+    catch (e:Dynamic)
+    {
+      Polymod.error(SCRIPT_RUNTIME_EXCEPTION, 'Could not construct instance of compiled class ($clsName): $e', SCRIPT_RUNTIME);
+      return null;
+    }
+  }
+
+  override public function buildASC(?args:Array<Dynamic>):PolymodAbstractScriptClass
+  {
+    Polymod.error(SCRIPT_RUNTIME_EXCEPTION, 'Compiled class ($clsName) has no script class to build.', SCRIPT_RUNTIME);
+    return null;
+  }
+
+  override public function callFunction(funcName:String, ?args:Array<Dynamic>):Dynamic
+  {
+    var fn:Dynamic = Reflect.field(cppiaClass, funcName);
+    if (fn == null)
+    {
+      Polymod.error(SCRIPT_RUNTIME_EXCEPTION, 'Compiled class ($clsName) has no static function "$funcName".', SCRIPT_RUNTIME);
+      return null;
+    }
+    return Reflect.callMethod(cppiaClass, fn, args ?? []);
+  }
+
+  override public function getField(fieldName:String):Dynamic
+  {
+    return Reflect.field(cppiaClass, fieldName);
+  }
+
+  override public function setField(fieldName:String, fieldValue:Dynamic):Dynamic
+  {
+    Reflect.setField(cppiaClass, fieldName, fieldValue);
+    return fieldValue;
+  }
+
+  override public function getFullyQualifiedName():String
+  {
+    return clsName;
+  }
+
+  override public function toString():String
+  {
+    return 'PolymodCppiaClassReference($clsName)';
+  }
+}

--- a/polymod/hscript/_internal/PolymodCppiaClassReference.hx
+++ b/polymod/hscript/_internal/PolymodCppiaClassReference.hx
@@ -10,6 +10,16 @@ class PolymodCppiaClassReference extends PolymodStaticClassReference
   static final registry:Map<String, Class<Dynamic>> = new Map<String, Class<Dynamic>>();
 
   /**
+   * What each file gave us, kept across reloads.
+   */
+  static final loadedModules:Map<String, LoadedCppiaModule> = new Map<String, LoadedCppiaModule>();
+
+  /**
+   * Every class name any compiled script has ever provided, kept for the life of the process.
+   */
+  static final everProvided:Map<String, Bool> = new Map<String, Bool>();
+
+  /**
    * The version a cppia must be stamped with to be accepted.
    */
   public static var expectedVersion:Null<String> = null;
@@ -18,13 +28,83 @@ class PolymodCppiaClassReference extends PolymodStaticClassReference
 
   public static function clearCppiaClasses():Void
   {
+    // Only the active registry is dropped. What was loaded stays known, because it cannot be undone.
     registry.clear();
     reportedMismatch = false;
+  }
+
+  /**
+   * Signature of a file's contents, used to tell a reload of the same bytes from a rebuilt mod.
+   */
+  static function signatureOf(data:haxe.io.Bytes):String
+  {
+    return '${data.length}:${haxe.crypto.Crc32.make(data)}';
   }
 
   public static function hasCppiaClass(clsName:String):Bool
   {
     return registry.exists(clsName);
+  }
+
+  /**
+   * Whether this name belongs to a compiled script that is no longer loaded.
+   *
+   * The class object still exists, because hxcpp cannot unload it, but nothing should resolve to it.
+   */
+  public static function isInactiveCppiaClass(clsName:String):Bool
+  {
+    return everProvided.exists(clsName) && !registry.exists(clsName);
+  }
+
+  /**
+   * Free the code of every module whose classes are no longer registered.
+   */
+  public static function unloadInactiveModules():Void
+  {
+    #if (hxcpp && POLYMOD_CPPIA)
+    // Snapshot the keys, the loop removes entries.
+    for (path in [for (key in loadedModules.keys()) key])
+    {
+      var loaded:LoadedCppiaModule = loadedModules.get(path);
+
+      var active:Array<String> = loaded.names.filter(name -> registry.exists(name));
+
+      if (active.length == loaded.names.length) continue;
+
+      if (active.length > 0)
+      {
+        // Another script re-registered part of this one's classes.
+        Polymod.warning(SCRIPT_PARSE_FAILED,
+          'Compiled script "$path" is partly still in use (${active.join(", ")} of ${loaded.names.join(", ")}), so it cannot be unloaded. Two scripts are probably providing the same class.',
+          SCRIPT_RUNTIME);
+        continue;
+      }
+
+      if (!unloadModule(loaded, path)) continue;
+
+      loadedModules.remove(path);
+      trace('[cppia] unloaded "$path", its mod is no longer enabled.');
+    }
+    #end
+  }
+
+  /**
+   * Free one module's code, reporting rather than throwing if the native side refuses.
+   * @return Whether the module was actually unloaded.
+   */
+  static function unloadModule(loaded:LoadedCppiaModule, path:String):Bool
+  {
+    try
+    {
+      loaded.unload();
+      return true;
+    }
+    catch (e:Dynamic)
+    {
+      Polymod.error(SCRIPT_RUNTIME_EXCEPTION,
+        'Failed to unload compiled script "$path": $e. Its code stays in memory until the game restarts.', SCRIPT_RUNTIME);
+      return false;
+    }
   }
 
   public static function listCppiaClasses():Array<String>
@@ -70,16 +150,66 @@ class PolymodCppiaClassReference extends PolymodStaticClassReference
   public static function registerModule(data:haxe.io.Bytes, path:String):Array<String>
   {
     #if (hxcpp && POLYMOD_CPPIA)
+    if (data == null || data.length == 0)
+    {
+      Polymod.error(SCRIPT_PARSE_FAILED, 'Compiled script "$path" is empty, rebuild it with the current build command.', SCRIPT_RUNTIME);
+      return [];
+    }
+
+    var signature:String = signatureOf(data);
+    var previous:LoadedCppiaModule = loadedModules.get(path);
+
+    if (previous != null && previous.signature == signature)
+    {
+      // Same bytes as last time. Put the classes we already have back in the registry.
+      for (i in 0...previous.names.length)
+      {
+        registry.set(previous.names[i], previous.refs[i]);
+        everProvided.set(previous.names[i], true);
+      }
+
+      trace('[cppia] reused "$path" providing ${previous.names.join(", ")}, unchanged since it was loaded.');
+      return previous.names.copy();
+    }
+
+    if (previous != null)
+    {
+      Polymod.info(SCRIPT_PARSE_START,
+        'Compiled script "$path" changed since it was loaded, unloading the previous copy.', SCRIPT_RUNTIME);
+
+      unloadModule(previous, path);
+      loadedModules.remove(path);
+    }
+
     var module:cpp.cppia.Module = null;
+
+    trace('[cppia] reading "$path" (${data.length} bytes)...');
 
     try
     {
       module = cpp.cppia.Module.fromData(data.getData());
+    }
+    catch (e:Dynamic)
+    {
+      Polymod.error(SCRIPT_PARSE_FAILED, 'Failed to read compiled script "$path": $e', SCRIPT_RUNTIME);
+      return [];
+    }
+
+    if (module == null)
+    {
+      Polymod.error(SCRIPT_PARSE_FAILED, 'Compiled script "$path" produced no module, it is probably corrupt.', SCRIPT_RUNTIME);
+      return [];
+    }
+
+    trace('[cppia] booting "$path"...');
+
+    try
+    {
       module.boot();
     }
     catch (e:Dynamic)
     {
-      Polymod.error(SCRIPT_PARSE_FAILED, 'Failed to load compiled script "$path": $e', SCRIPT_RUNTIME);
+      Polymod.error(SCRIPT_PARSE_FAILED, 'Failed to boot compiled script "$path": $e', SCRIPT_RUNTIME);
       return [];
     }
 
@@ -119,17 +249,43 @@ class PolymodCppiaClassReference extends PolymodStaticClassReference
       return [];
     }
 
+    var expectedNames:Array<String> = cast Reflect.field(manifest, 'classes');
+
     var registered:Array<String> = [];
-    for (cls in declared)
+    var registeredRefs:Array<Class<Dynamic>> = [];
+    for (i in 0...declared.length)
     {
-      if (cls == null) continue;
+      var cls = declared[i];
+      var expectedName:String = (expectedNames != null && i < expectedNames.length) ? expectedNames[i] : 'entry $i';
+
+      if (cls == null)
+      {
+        Polymod.error(SCRIPT_PARSE_FAILED, 'Compiled script "$path" declares "$expectedName" but the module did not provide it, rebuild it with the current build command.',
+          SCRIPT_RUNTIME);
+        continue;
+      }
 
       var name = Type.getClassName(cls);
-      if (name == null) continue;
+      if (name == null)
+      {
+        Polymod.error(SCRIPT_PARSE_FAILED, 'Compiled script "$path" provided an unnamed class for "$expectedName".', SCRIPT_RUNTIME);
+        continue;
+      }
+
+      if (registry.exists(name))
+      {
+        Polymod.warning(SCRIPT_PARSE_FAILED, 'Compiled class "$name" was already registered, "$path" is replacing it.', SCRIPT_RUNTIME);
+      }
 
       registry.set(name, cls);
+      everProvided.set(name, true);
       registered.push(name);
+      registeredRefs.push(cls);
     }
+
+    loadedModules.set(path, new LoadedCppiaModule(signature, registered, registeredRefs, module));
+
+    trace('[cppia] loaded "$path" providing ${registered.join(", ")}');
 
     return registered;
     #else
@@ -149,13 +305,26 @@ class PolymodCppiaClassReference extends PolymodStaticClassReference
 
   override public function instantiate(?args:Array<Dynamic>):Null<Dynamic>
   {
+    if (cppiaClass == null)
+    {
+      Polymod.error(SCRIPT_RUNTIME_EXCEPTION, 'Compiled class ($clsName) is not loaded, so it cannot be constructed.', SCRIPT_RUNTIME);
+      return null;
+    }
+
+    var callArgs:Array<Dynamic> = args ?? [];
+
     try
     {
-      return Type.createInstance(cppiaClass, args ?? []);
+      var result = Type.createInstance(cppiaClass, callArgs);
+      if (result == null)
+      {
+        Polymod.error(SCRIPT_RUNTIME_EXCEPTION, 'Constructing compiled class ($clsName) with ${callArgs.length} argument(s) returned null.', SCRIPT_RUNTIME);
+      }
+      return result;
     }
     catch (e:Dynamic)
     {
-      Polymod.error(SCRIPT_RUNTIME_EXCEPTION, 'Could not construct instance of compiled class ($clsName): $e', SCRIPT_RUNTIME);
+      Polymod.error(SCRIPT_RUNTIME_EXCEPTION, 'Could not construct compiled class ($clsName) with ${callArgs.length} argument(s): $e', SCRIPT_RUNTIME);
       return null;
     }
   }
@@ -168,22 +337,56 @@ class PolymodCppiaClassReference extends PolymodStaticClassReference
 
   override public function callFunction(funcName:String, ?args:Array<Dynamic>):Dynamic
   {
+    if (cppiaClass == null)
+    {
+      Polymod.error(SCRIPT_RUNTIME_EXCEPTION, 'Compiled class ($clsName) is not loaded, so "$funcName" cannot be called.', SCRIPT_RUNTIME);
+      return null;
+    }
+
     var fn:Dynamic = Reflect.field(cppiaClass, funcName);
     if (fn == null)
     {
       Polymod.error(SCRIPT_RUNTIME_EXCEPTION, 'Compiled class ($clsName) has no static function "$funcName".', SCRIPT_RUNTIME);
       return null;
     }
-    return Reflect.callMethod(cppiaClass, fn, args ?? []);
+
+    if (!Reflect.isFunction(fn))
+    {
+      Polymod.error(SCRIPT_RUNTIME_EXCEPTION, 'Compiled class ($clsName) field "$funcName" is not a function.', SCRIPT_RUNTIME);
+      return null;
+    }
+
+    // A script calling into compiled code must not take the whole game down on a bad call.
+    try
+    {
+      return Reflect.callMethod(cppiaClass, fn, args ?? []);
+    }
+    catch (e:Dynamic)
+    {
+      Polymod.error(SCRIPT_RUNTIME_EXCEPTION, 'Compiled class ($clsName) threw calling "$funcName": $e', SCRIPT_RUNTIME);
+      return null;
+    }
   }
 
   override public function getField(fieldName:String):Dynamic
   {
+    if (cppiaClass == null)
+    {
+      Polymod.error(SCRIPT_RUNTIME_EXCEPTION, 'Compiled class ($clsName) is not loaded, so "$fieldName" cannot be read.', SCRIPT_RUNTIME);
+      return null;
+    }
+
     return Reflect.field(cppiaClass, fieldName);
   }
 
   override public function setField(fieldName:String, fieldValue:Dynamic):Dynamic
   {
+    if (cppiaClass == null)
+    {
+      Polymod.error(SCRIPT_RUNTIME_EXCEPTION, 'Compiled class ($clsName) is not loaded, so "$fieldName" cannot be written.', SCRIPT_RUNTIME);
+      return null;
+    }
+
     Reflect.setField(cppiaClass, fieldName, fieldValue);
     return fieldValue;
   }
@@ -196,5 +399,41 @@ class PolymodCppiaClassReference extends PolymodStaticClassReference
   override public function toString():String
   {
     return 'PolymodCppiaClassReference($clsName)';
+  }
+}
+
+@:headerInclude("hx/Scriptable.h")
+private class LoadedCppiaModule
+{
+  public final signature:String;
+  public final names:Array<String>;
+  public final refs:Array<Class<Dynamic>>;
+
+  #if (hxcpp && POLYMOD_CPPIA)
+  var module:Null<cpp.cppia.Module>;
+  #end
+
+  public function new(signature:String, names:Array<String>, refs:Array<Class<Dynamic>>, module:Dynamic)
+  {
+    this.signature = signature;
+    this.names = names;
+    this.refs = refs;
+    #if (hxcpp && POLYMOD_CPPIA)
+    this.module = module;
+    #end
+  }
+
+  /**
+   * Free the module's code.
+   */
+  public function unload():Void
+  {
+    #if (hxcpp && POLYMOD_CPPIA)
+    if (module == null) return;
+
+    var m = module;
+    module = null;
+    untyped __cpp__("{0}->unload()", m);
+    #end
   }
 }

--- a/polymod/hscript/_internal/PolymodCppiaClassReference.hx
+++ b/polymod/hscript/_internal/PolymodCppiaClassReference.hx
@@ -477,11 +477,7 @@ class PolymodCppiaClassReference extends PolymodStaticClassReference
 
     if (previous != null)
     {
-      Polymod.info(SCRIPT_PARSE_START,
-        'Compiled script "$path" changed since it was loaded, unloading the previous copy.', SCRIPT_RUNTIME);
-
-      unloadModule(previous, path);
-      loadedModules.remove(path);
+      Polymod.info(SCRIPT_PARSE_START, 'Compiled script "$path" changed since it was loaded, it will be replaced.', SCRIPT_RUNTIME);
     }
 
     var scan:CppiaScan = null;
@@ -668,6 +664,12 @@ class PolymodCppiaClassReference extends PolymodStaticClassReference
       everProvided.set(name, true);
       registered.push(name);
       registeredRefs.push(cls);
+    }
+
+    if (previous != null)
+    {
+      unloadModule(previous, path);
+      loadedModules.remove(path);
     }
 
     loadedModules.set(path, new LoadedCppiaModule(signature, registered, registeredRefs, module));

--- a/polymod/hscript/_internal/PolymodCppiaClassReference.hx
+++ b/polymod/hscript/_internal/PolymodCppiaClassReference.hx
@@ -136,6 +136,68 @@ class PolymodCppiaClassReference extends PolymodStaticClassReference
     return result;
   }
 
+  /**
+   * The names a compiled script may not reference.
+   */
+  static function deniedNames():Map<String, Bool>
+  {
+    var result:Map<String, Bool> = new Map<String, Bool>();
+
+    for (name => alias in PolymodScriptClass.importOverrides)
+    {
+      if (alias == null || Type.getClassName(alias) != name) result.set(name, true);
+    }
+
+    return result;
+  }
+
+  /**
+   * Which denied name a type resolves to, if any.
+   */
+  static function deniedNameFor(type:String, denied:Map<String, Bool>):Null<String>
+  {
+    if (denied.exists(type)) return type;
+
+    var parts:Array<String> = type.split('.');
+    for (i in 1...parts.length)
+    {
+      var suffix:String = parts.slice(i).join('.');
+      if (denied.exists(suffix)) return suffix;
+    }
+
+    return null;
+  }
+
+  /**
+   * Check a compiled script against the blacklist before any of it runs.
+   * @return The denied names it references, or null if the file could not be read at all.
+   */
+  static function scanDenied(data:haxe.io.Bytes, path:String):Null<Array<String>>
+  {
+    var types:Array<String> = null;
+
+    try
+    {
+      types = PolymodCppiaScanner.readTypes(data);
+    }
+    catch (e:Dynamic)
+    {
+      Polymod.error(SCRIPT_PARSE_FAILED, 'Could not read the header of compiled script "$path": $e', SCRIPT_RUNTIME);
+      return null;
+    }
+
+    var denied:Map<String, Bool> = deniedNames();
+    var found:Array<String> = [];
+
+    for (type in types)
+    {
+      var name:Null<String> = deniedNameFor(type, denied);
+      if (name != null && !found.contains(name)) found.push(name);
+    }
+
+    return found;
+  }
+
   public static function tryBuildCppia(clsName:String):Null<PolymodCppiaClassReference>
   {
     var cls = registry.get(clsName);
@@ -179,6 +241,17 @@ class PolymodCppiaClassReference extends PolymodStaticClassReference
 
       unloadModule(previous, path);
       loadedModules.remove(path);
+    }
+
+    var denied:Null<Array<String>> = scanDenied(data, path);
+    if (denied == null) return [];
+
+    if (denied.length > 0)
+    {
+      Polymod.error(SCRIPT_PARSE_FAILED,
+        'Compiled script "$path" references ${denied.length == 1 ? "a class" : "classes"} that mods are not allowed to use: ${denied.join(", ")}. It will not be loaded.',
+        SCRIPT_RUNTIME);
+      return [];
     }
 
     var module:cpp.cppia.Module = null;

--- a/polymod/hscript/_internal/PolymodCppiaClassReference.hx
+++ b/polymod/hscript/_internal/PolymodCppiaClassReference.hx
@@ -78,6 +78,24 @@ class PolymodCppiaClassReference extends PolymodStaticClassReference
   }
 
   /**
+   * Whether an hscript class can extend this one.
+   */
+  public static function isExtendableCppiaClass(clsName:String):Bool
+  {
+    var cls:Null<Class<Dynamic>> = registry.get(clsName);
+    if (cls == null) return false;
+
+    try
+    {
+      return Reflect.field(cls, '_isHScriptedClass') == true;
+    }
+    catch (_:Dynamic)
+    {
+      return false;
+    }
+  }
+
+  /**
    * Whether this name belongs to a compiled script that is no longer loaded.
    *
    * The class object still exists, because hxcpp cannot unload it, but nothing should resolve to it.
@@ -178,6 +196,7 @@ class PolymodCppiaClassReference extends PolymodStaticClassReference
     {
       if (alias == null || Type.getClassName(alias) != name) result.set(name, true);
     }
+    result.remove(Type.getClassName(polymod.hscript.PolymodScriptBridge));
 
     return result;
   }

--- a/polymod/hscript/_internal/PolymodCppiaScanner.hx
+++ b/polymod/hscript/_internal/PolymodCppiaScanner.hx
@@ -1,0 +1,134 @@
+package polymod.hscript._internal;
+
+/**
+ * Reads the header of a compiled script.
+ */
+class PolymodCppiaScanner
+{
+  /**
+   * Every type a compiled script references.
+   * @throws String if the file is not a cppia we can read.
+   */
+  public static function readTypes(data:haxe.io.Bytes):Array<String>
+  {
+    if (data == null || data.length == 0) throw 'empty file';
+
+    var reader = new CppiaHeaderReader(data);
+
+    var magic:String = reader.token();
+    if (magic != 'CPPIA' && magic != 'CPPIB') throw 'not a compiled script, magic was "$magic"';
+
+    var stringCount:Int = reader.int();
+    if (stringCount < 0) throw 'bad string count $stringCount';
+    for (_ in 0...stringCount)
+      reader.skipString();
+
+    var typeCount:Int = reader.int();
+    if (typeCount < 0) throw 'bad type count $typeCount';
+
+    return [for (_ in 0...typeCount) reader.string()];
+  }
+}
+
+/**
+ * Walks a `CppiaStream` to read the header of a compiled script.
+ */
+private class CppiaHeaderReader
+{
+  final data:haxe.io.Bytes;
+
+  var pos:Int = 0;
+
+  public function new(data:haxe.io.Bytes)
+  {
+    this.data = data;
+  }
+
+  public function token():String
+  {
+    skipWhitespace();
+    var start:Int = pos;
+    while (pos < data.length && data.get(pos) > 32)
+      pos++;
+    return data.getString(start, pos - start);
+  }
+
+  public function int():Int
+  {
+    skipWhitespace();
+
+    var result:Int = 0;
+    var sign:Int = 1;
+    var digits:Int = 0;
+
+    while (pos < data.length && data.get(pos) > 32)
+    {
+      var c:Int = data.get(pos);
+      if (c == '-'.code)
+      {
+        sign = -1;
+      }
+      else
+      {
+        var digit:Int = c - '0'.code;
+        if (digit < 0 || digit > 9) throw 'expected a digit at byte $pos';
+        result = result * 10 + digit;
+        digits++;
+      }
+      pos++;
+    }
+
+    if (digits == 0) throw 'expected a number at byte $pos';
+
+    return result * sign;
+  }
+
+  public function string():String
+  {
+    var start:Int = takeString();
+    return data.getString(start, pos - start);
+  }
+
+  public function skipString():Void
+  {
+    takeString();
+  }
+
+  /**
+   * Advance past one length prefixed string.
+   * @return Where its bytes started.
+   */
+  function takeString():Int
+  {
+    var len:Int = int();
+    if (len < 0) throw 'bad string length $len at byte $pos';
+
+    // One separator byte sits between the length and the bytes.
+    pos++;
+
+    var start:Int = pos;
+    pos += len;
+    if (pos > data.length) throw 'ran off the end of the file';
+
+    return start;
+  }
+
+  function skipWhitespace():Void
+  {
+    while (true)
+    {
+      while (pos < data.length && data.get(pos) <= 32)
+        pos++;
+
+      if (pos < data.length && data.get(pos) == '#'.code)
+      {
+        while (pos < data.length && data.get(pos) != '\n'.code)
+          pos++;
+      }
+      else
+      {
+        break;
+      }
+    }
+  }
+}

--- a/polymod/hscript/_internal/PolymodCppiaScanner.hx
+++ b/polymod/hscript/_internal/PolymodCppiaScanner.hx
@@ -1,37 +1,318 @@
 package polymod.hscript._internal;
 
 /**
- * Reads the header of a compiled script.
+ * What reading a compiled script turned up.
+ */
+class CppiaScan
+{
+  /**
+   * True if the file used the CPPIB binary encoding.
+   */
+  public var binary:Bool = false;
+
+  /**
+   * The string table. Field names live here.
+   */
+  public var strings:Array<String> = [];
+
+  /**
+   * The type table. Index 0 is the empty name, which means Dynamic.
+   */
+  public var types:Array<String> = [];
+
+  /**
+   * Whether the body was actually walked, rather than skipped as having nothing to find.
+   */
+  public var walked:Bool = false;
+
+  /**
+   * True if the body did not read the way a compiled script should, so nothing found here can be
+   * trusted.
+   */
+  public var suspect:Bool = false;
+
+  /**
+   * Field references worth a closer look, flattened as classId, fieldId, classId, fieldId...
+   */
+  public var fieldRefs:Array<Int> = [];
+
+  /**
+   * Where each of those came from, flattened as fileStringId, line, fileStringId, line...
+   */
+  public var fieldSites:Array<Int> = [];
+
+  /**
+   * Calls to hxcpp builtins, flattened as nameStringId, argCount, nameStringId, argCount...
+   */
+  public var globalCalls:Array<Int> = [];
+
+  /**
+   * Every type this module declares, mapped to its super type id followed by the type ids of the
+   * interfaces it implements.
+   */
+  public var ancestry:Map<Int, Array<Int>> = new Map<Int, Array<Int>>();
+
+  /**
+   * Tokens the walk did not recognise, so a change in hxcpp is easy to spot.
+   */
+  public var unknownTokens:Array<String> = [];
+
+  public function new() {}
+}
+
+/**
+ * Reads a compiled script without running any of it.
  */
 class PolymodCppiaScanner
 {
+  static final FIELD_OPS:Map<String, Bool> = [
+    'FSTATIC' => true,
+    'CALLSTATIC' => true,
+    'FNAME' => true,
+    'FTHISNAME' => true,
+    'FLINK' => true,
+    'FTHISINST' => true,
+    'CALLMEMBER' => true,
+    'CALLTHIS' => true,
+    'CALLSUPER' => true,
+    'FENUM' => true,
+    'CREATEENUM' => true
+  ];
+
+  static final BODY_TOKENS:Map<String, Bool> = [
+    'FUNCTION' => true, 'VAR' => true, 'TOINTERFACE' => true, 'TODYNARRAY' => true,
+    'TODATAARRAY' => true, 'TOINTERFACEARRAY' => true, 'FUN' => true, 'CAST' => true,
+    'BLOCK' => true, 'BREAK' => true, 'CONTINUE' => true, 'ISNULL' => true, 'NOTNULL' => true,
+    'SET' => true, 'CALL' => true, 'CALLGLOBAL' => true, 'CALLSTATIC' => true,
+    'CALLMEMBER' => true, 'CALLSUPER' => true, 'CALLTHIS' => true, 'CALLSUPERNEW' => true,
+    'CREATEENUM' => true, 'ADEF' => true, 'IF' => true, 'IFELSE' => true, 'FNAME' => true,
+    'FSTATIC' => true, 'FTHISINST' => true, 'FLINK' => true, 'FTHISNAME' => true, 'FENUM' => true,
+    'THROW' => true, 'ARRAYI' => true, '++' => true, '+++' => true, '--' => true, '---' => true,
+    'NEG' => true, '~' => true, '!' => true, 'TVARS' => true, 'VARDECL' => true,
+    'VARDECLI' => true, 'NEW' => true, 'RETURN' => true, 'RETVAL' => true, 'POSINFO' => true,
+    'OBJDEF' => true, 'CLASSOF' => true, 'WHILE' => true, 'FOR' => true, 'ENUMI' => true,
+    'SWITCH' => true, 'TRY' => true, 'IMPLDYNAMIC' => true, 'i' => true, 'f' => true,
+    's' => true, 'false' => true, 'true' => true, 'NULL' => true, 'THIS' => true,
+    'SUPER' => true, 'CASTINT' => true, 'CASTBOOL' => true, 'INTERFACE' => true, 'CLASS' => true,
+    'N' => true, 'n' => true, 'R' => true, 'C' => true, 'ENUM' => true, 'INLINE' => true,
+    'MAIN' => true, 'NOMAIN' => true, 'RESOURCES' => true, 'RESO' => true, 'NOCAST' => true,
+    'V' => true, '+' => true, '*' => true, '/' => true, '-' => true, '=' => true, '==' => true,
+    '!=' => true, '>=' => true, '<=' => true, '>' => true, '<' => true, '&' => true, '|' => true,
+    '^' => true, '&&' => true, '||' => true, '>>' => true, '>>>' => true, '<<' => true,
+    '%' => true, '...' => true, '=>' => true, '+=' => true, '*=' => true, '/=' => true,
+    '-=' => true, '&=' => true, '|=' => true, '^=' => true, '&&=' => true, '||=' => true,
+    '>>=' => true, '>>>=' => true, '<<=' => true, '%=' => true, 'TCAST' => true
+  ];
+
   /**
    * Every type a compiled script references.
    * @throws String if the file is not a cppia we can read.
    */
   public static function readTypes(data:haxe.io.Bytes):Array<String>
   {
+    return scan(data).types;
+  }
+
+  /**
+   * Read a compiled script's header, and scan it.
+   * @param data The file.
+   * @param wantedFields Field names to watch for. Pass null to read the header only.
+   * @param wantGlobals Whether to also record calls to hxcpp builtins.
+   * @throws String if the file is not a cppia we can read.
+   */
+  public static function scan(data:haxe.io.Bytes, ?wantedFields:Map<String, Bool>, wantGlobals:Bool = false):CppiaScan
+  {
     if (data == null || data.length == 0) throw 'empty file';
 
+    var result:CppiaScan = new CppiaScan();
     var reader = new CppiaHeaderReader(data);
 
     var magic:String = reader.token();
     if (magic != 'CPPIA' && magic != 'CPPIB') throw 'not a compiled script, magic was "$magic"';
 
+    result.binary = magic == 'CPPIB';
+
     var stringCount:Int = reader.int();
     if (stringCount < 0) throw 'bad string count $stringCount';
-    for (_ in 0...stringCount)
-      reader.skipString();
+    result.strings = [for (_ in 0...stringCount) reader.string()];
 
     var typeCount:Int = reader.int();
     if (typeCount < 0) throw 'bad type count $typeCount';
+    result.types = [for (_ in 0...typeCount) reader.string()];
 
-    return [for (_ in 0...typeCount) reader.string()];
+    if (wantedFields == null || result.binary) return result;
+
+    var wantedIds:Map<Int, Bool> = new Map<Int, Bool>();
+    var wantedAny:Bool = false;
+
+    for (i in 0...result.strings.length)
+    {
+      if (wantedFields.exists(result.strings[i]))
+      {
+        wantedIds.set(i, true);
+        wantedAny = true;
+      }
+    }
+
+    var needGlobals:Bool = false;
+
+    if (wantGlobals)
+    {
+      for (name in result.strings)
+      {
+        if (StringTools.startsWith(name, '__hxcpp_'))
+        {
+          needGlobals = true;
+          break;
+        }
+      }
+    }
+
+    // Nothing this module could name is worth looking at, so the body never has to be read.
+    if (!wantedAny && !needGlobals) return result;
+
+    walk(reader, result, wantedIds, needGlobals);
+    return result;
+  }
+
+  /**
+   * Read the body a token at a time, picking out the few expressions that name a field.
+   */
+  static function walk(reader:CppiaHeaderReader, result:CppiaScan, wantedIds:Map<Int, Bool>, wantGlobals:Bool):Void
+  {
+    result.walked = true;
+
+    var fileId:Int = 0;
+    var line:Int = 0;
+
+    while (reader.hasMore())
+    {
+      var token:String = reader.token();
+      if (token.length == 0) break;
+
+      var number:Null<Int> = numberOf(token);
+      if (number != null)
+      {
+        fileId = line;
+        line = number;
+        continue;
+      }
+
+      if (token == 'RESOURCES') break;
+
+      if (token == 'CLASS' || token == 'INTERFACE')
+      {
+        var typeId:Null<Int> = reader.intOrNull();
+        var superId:Null<Int> = reader.intOrNull();
+        var implementCount:Null<Int> = reader.intOrNull();
+
+        if (typeId == null || superId == null || implementCount == null || implementCount < 0)
+        {
+          result.suspect = true;
+          return;
+        }
+
+        var count:Int = implementCount;
+        var related:Array<Int> = [superId];
+
+        for (_ in 0...count)
+        {
+          var implementId:Null<Int> = reader.intOrNull();
+          if (implementId == null)
+          {
+            result.suspect = true;
+            return;
+          }
+          related.push(implementId);
+        }
+
+        result.ancestry.set(typeId, related);
+        continue;
+      }
+
+      if (token == 'ENUM')
+      {
+        var typeId:Null<Int> = reader.intOrNull();
+
+        if (typeId == null)
+        {
+          result.suspect = true;
+          return;
+        }
+
+        result.ancestry.set(typeId, []);
+        continue;
+      }
+
+      if (token == 'CALLGLOBAL')
+      {
+        var nameId:Null<Int> = reader.intOrNull();
+        var argCount:Null<Int> = reader.intOrNull();
+
+        if (nameId == null || argCount == null)
+        {
+          result.suspect = true;
+          return;
+        }
+
+        if (wantGlobals)
+        {
+          result.globalCalls.push(nameId);
+          result.globalCalls.push(argCount);
+        }
+        continue;
+      }
+
+      if (FIELD_OPS.exists(token))
+      {
+        var classId:Null<Int> = reader.intOrNull();
+        var fieldId:Null<Int> = reader.intOrNull();
+
+        if (classId == null || fieldId == null)
+        {
+          result.suspect = true;
+          return;
+        }
+
+        if (wantedIds.exists(fieldId))
+        {
+          result.fieldRefs.push(classId);
+          result.fieldRefs.push(fieldId);
+          result.fieldSites.push(fileId);
+          result.fieldSites.push(line);
+        }
+        continue;
+      }
+
+      if (!BODY_TOKENS.exists(token) && !result.unknownTokens.contains(token)) result.unknownTokens.push(token);
+    }
+  }
+
+  /**
+   * The value of a token written as a decimal integer, or null if it is not one.
+   */
+  static function numberOf(token:String):Null<Int>
+  {
+    if (token == null || token.length == 0) return null;
+
+    var start:Int = token.charCodeAt(0) == '-'.code ? 1 : 0;
+    if (start >= token.length) return null;
+
+    var value:Int = 0;
+
+    for (i in start...token.length)
+    {
+      var digit:Int = token.charCodeAt(i) - '0'.code;
+      if (digit < 0 || digit > 9) return null;
+      value = value * 10 + digit;
+    }
+
+    return start == 1 ? -value : value;
   }
 }
 
 /**
- * Walks a `CppiaStream` to read the header of a compiled script.
+ * Walks a `CppiaStream` to read a compiled script.
  */
 private class CppiaHeaderReader
 {
@@ -51,6 +332,15 @@ private class CppiaHeaderReader
     while (pos < data.length && data.get(pos) > 32)
       pos++;
     return data.getString(start, pos - start);
+  }
+
+  /**
+   * Whether anything but whitespace is left.
+   */
+  public function hasMore():Bool
+  {
+    skipWhitespace();
+    return pos < data.length;
   }
 
   public function int():Int
@@ -79,6 +369,40 @@ private class CppiaHeaderReader
     }
 
     if (digits == 0) throw 'expected a number at byte $pos';
+
+    return result * sign;
+  }
+
+  /**
+   * The next token as an integer, or null if it is not one.
+   */
+  public function intOrNull():Null<Int>
+  {
+    skipWhitespace();
+
+    var result:Int = 0;
+    var sign:Int = 1;
+    var digits:Int = 0;
+    var bad:Bool = false;
+
+    while (pos < data.length && data.get(pos) > 32)
+    {
+      var c:Int = data.get(pos);
+      if (c == '-'.code)
+      {
+        sign = -1;
+      }
+      else
+      {
+        var digit:Int = c - '0'.code;
+        if (digit < 0 || digit > 9) bad = true;
+        result = result * 10 + digit;
+        digits++;
+      }
+      pos++;
+    }
+
+    if (bad || digits == 0) return null;
 
     return result * sign;
   }

--- a/polymod/hscript/_internal/PolymodScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodScriptClass.hx
@@ -722,6 +722,20 @@ class PolymodScriptClass
         {
           targetClass = scriptClassOverrides.get(clsPath);
         }
+        #if POLYMOD_CPPIA
+        else if (PolymodCppiaClassReference.hasCppiaClass(clsPath))
+        {
+          if (!PolymodCppiaClassReference.isExtendableCppiaClass(clsPath))
+          {
+            Polymod.error(SCRIPT_PARSE_FAILED,
+              'Cannot extend compiled class ("${Util.getFullClassName(c)}" tried extending "$clsPath"). Mark it with @:hscriptExtendable and rebuild the compiled script.',
+              SCRIPT_RUNTIME);
+            return;
+          }
+
+          targetClass = PolymodCppiaClassReference.getCppiaClass(clsPath);
+        }
+        #end
         else if (c.imports.exists(clsName))
         {
           var importedClass:ClassImport = c.imports.get(clsName);
@@ -855,6 +869,17 @@ class PolymodScriptClass
           _interp.error(EClassUnresolvedSuperclass(fullExtendString, 'WHY?'));
         }
       }
+      #if POLYMOD_CPPIA
+      else if (PolymodCppiaClassReference.hasCppiaClass(fullExtendString))
+      {
+        clsToCreate = PolymodCppiaClassReference.getCppiaClass(fullExtendString);
+
+        if (clsToCreate == null)
+        {
+          _interp.error(EClassUnresolvedSuperclass(fullExtendString, 'no loaded compiled script provides it'));
+        }
+      }
+      #end
       else if (_c.imports.exists(extendString))
       {
         clsToCreate = _c.imports.get(extendString).cls;

--- a/polymod/hscript/_internal/PolymodScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodScriptClass.hx
@@ -50,6 +50,171 @@ class PolymodScriptClass
    */
   public static final blacklistedInstanceFields:Map<String, Array<String>> = new Map<String, Array<String>>();
 
+  /**
+   * Field names that may not be reached even through a receiver whose type is not known.
+   */
+  public static final blacklistedDynamicFieldNames:Map<String, Bool> = new Map<String, Bool>();
+
+  /**
+   * Bumped whenever a blacklist changes, so anything caching a lookup can tell it went stale.
+   */
+  public static var blacklistGeneration(default, null):Int = 0;
+
+  /**
+   * `blacklistedStaticFields` re-keyed by class name, since a compiled script only knows names.
+   */
+  static var staticFieldsByNameCache:Null<Map<String, Array<String>>> = null;
+
+  /**
+   * Class name to every blacklisted instance field it has, inherited ones included.
+   */
+  static var resolvedInstanceFields:Map<String, Array<String>> = new Map<String, Array<String>>();
+
+  /**
+   * Throw away everything derived from the blacklists. Call after changing one.
+   */
+  public static function bumpBlacklistGeneration():Void
+  {
+    blacklistGeneration++;
+    staticFieldsByNameCache = null;
+    resolvedInstanceFields.clear();
+  }
+
+  /**
+   * The blacklisted static fields, keyed by class name instead of by class.
+   */
+  public static function staticFieldsByName():Map<String, Array<String>>
+  {
+    if (staticFieldsByNameCache != null) return staticFieldsByNameCache;
+
+    var result:Map<String, Array<String>> = new Map<String, Array<String>>();
+
+    for (cls in blacklistedStaticFields.keys())
+    {
+      var name:Null<String> = null;
+      try
+      {
+        name = Type.getClassName(cls);
+      }
+      catch (_:Dynamic) {}
+
+      if (name == null) continue;
+      result.set(name, blacklistedStaticFields.get(cls));
+    }
+
+    staticFieldsByNameCache = result;
+    return result;
+  }
+
+  /**
+   * Every name an instance of this class could be blacklisted under, itself first.
+   */
+  static function ancestorsOf(clsName:String):Array<String>
+  {
+    var result:Array<String> = [clsName];
+
+    var cls:Null<Class<Dynamic>> = null;
+    try
+    {
+      cls = Type.resolveClass(clsName);
+    }
+    catch (_:Dynamic) {}
+
+    // A hand written script could name a class that is its own super, so do not trust the chain.
+    var depth:Int = 0;
+    while (cls != null && depth++ < 64)
+    {
+      try
+      {
+        cls = Type.getSuperClass(cls);
+      }
+      catch (_:Dynamic)
+      {
+        break;
+      }
+
+      if (cls == null) break;
+
+      var name:Null<String> = Type.getClassName(cls);
+      if (name == null || result.contains(name)) break;
+
+      result.push(name);
+    }
+
+    return result;
+  }
+
+  /**
+   * Every blacklisted instance field reachable on this class.
+   */
+  public static function blacklistedInstanceFieldsOf(clsName:String):Array<String>
+  {
+    var cached:Null<Array<String>> = resolvedInstanceFields.get(clsName);
+    if (cached != null) return cached;
+
+    var result:Array<String> = [];
+
+    for (name in ancestorsOf(clsName))
+    {
+      var fields:Null<Array<String>> = blacklistedInstanceFields.get(name);
+      if (fields == null) continue;
+
+      for (field in fields)
+        if (!result.contains(field)) result.push(field);
+    }
+
+    resolvedInstanceFields.set(clsName, result);
+    return result;
+  }
+
+  /**
+   * Whether this field is blacklisted on this exact class, ignoring what it inherits.
+   */
+  public static function isBlacklistedFieldExact(clsName:String, field:String):Bool
+  {
+    if (clsName == null || clsName.length == 0) return false;
+
+    var statics:Null<Array<String>> = staticFieldsByName().get(clsName);
+    if (statics != null && statics.contains(field)) return true;
+
+    var fields:Null<Array<String>> = blacklistedInstanceFields.get(clsName);
+    return fields != null && fields.contains(field);
+  }
+
+  /**
+   * Whether this field is blacklisted on this class or on anything it extends.
+   */
+  public static function isBlacklistedField(clsName:String, field:String):Bool
+  {
+    if (clsName == null || clsName.length == 0) return false;
+
+    var statics:Null<Array<String>> = staticFieldsByName().get(clsName);
+    if (statics != null && statics.contains(field)) return true;
+
+    return blacklistedInstanceFieldsOf(clsName).contains(field);
+  }
+
+  /**
+   * Every field name any blacklist mentions.
+   */
+  public static function blacklistedFieldNames():Map<String, Bool>
+  {
+    var result:Map<String, Bool> = new Map<String, Bool>();
+
+    for (fields in staticFieldsByName())
+      for (field in fields)
+        result.set(field, true);
+
+    for (fields in blacklistedInstanceFields)
+      for (field in fields)
+        result.set(field, true);
+
+    for (field in blacklistedDynamicFieldNames.keys())
+      result.set(field, true);
+
+    return result;
+  }
+
   /*
    * STATIC METHODS
    */

--- a/polymod/hscript/_internal/PolymodScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodScriptClass.hx
@@ -324,9 +324,20 @@ class PolymodScriptClass
   public static function listScriptClassesExtending(clsPath:String):Array<String>
   {
     var result = [];
+
+    #if POLYMOD_CPPIA
+    // Do CPPIA first!
+    for (key in PolymodCppiaClassReference.listCppiaClassesExtending(clsPath))
+    {
+      result.push(key);
+    }
+    #end
+
     @:privateAccess
     for (key => value in Interp._scriptClassDescriptors)
     {
+      if (result.indexOf(key) != -1) continue;
+
       var superClasses = getSuperClasses(value);
       if (superClasses.indexOf(clsPath) != -1)
       {

--- a/polymod/hscript/_internal/PolymodStaticClassReference.hx
+++ b/polymod/hscript/_internal/PolymodStaticClassReference.hx
@@ -12,9 +12,9 @@ using StringTools;
  */
 class PolymodStaticClassReference
 {
-  public var cls:ClassDecl;
+  public var cls:Null<ClassDecl>;
 
-  public function new(cls:ClassDecl)
+  public function new(?cls:ClassDecl)
   {
     this.cls = cls;
   }
@@ -26,6 +26,12 @@ class PolymodStaticClassReference
    */
   public static function tryBuild(clsName:String):Null<PolymodStaticClassReference>
   {
+    #if POLYMOD_CPPIA
+    // cppia are first always before hscript
+    var cppia = PolymodCppiaClassReference.tryBuildCppia(clsName);
+    if (cppia != null) return cppia;
+    #end
+
     @:privateAccess {
       if (Interp._scriptClassDescriptors.exists(clsName))
       {


### PR DESCRIPTION
CPPIA support to supplement where hscript is too slow.

Requires https://github.com/FunkinCrew/hxcpp/tree/kade-github/cppia-unload

Works entirely with blacklisting fields and imports, along with being able to unload and reload scripts during runtime.