### PR TITLE
[BUGFIX] Fix preprocessor `elseif`s causing else Tokens to not be discarded

### DIFF
--- a/polymod/hscript/_internal/Parser.hx
+++ b/polymod/hscript/_internal/Parser.hx
@@ -2497,7 +2497,7 @@ class Parser
         {
           preprocStack[preprocStack.length - 1].r = false;
           skipTokens();
-          return token();
+          return id == 'else' ? token() : preprocess('if');
         }
         else if (id == "else")
         {


### PR DESCRIPTION
Fixes this issue
<img width="655" height="365" alt="image" src="https://github.com/user-attachments/assets/90b1bc0a-2558-466c-b947-20c4599502a4" />

Previously, using elseif in any preprocessor would make it assume that everything that comes afterwards is correct, even if not.

Some images of this working properly now:
<details><summary>The first case is True...</summary>
<p>
<img width="805" height="261" alt="image" src="https://github.com/user-attachments/assets/770d0fe2-9955-412d-b3d0-500e87371a8b" />
</p>
</details> 
<details><summary>The second case is True...</summary>
<p>
<img width="785" height="294" alt="image" src="https://github.com/user-attachments/assets/e9931017-c918-45e3-a71c-de744ba65edb" />
</p>
</details> 
<details><summary>The third case is True...</summary>
<p>
<img width="794" height="244" alt="image" src="https://github.com/user-attachments/assets/33e198aa-7785-409d-a1b5-bf1a6e7c9cc2" />
</p>
</details> 