### PR TITLE
[BUGFIX] Fix function overrides creating confusing crashlogs

### DIFF
--- a/polymod/hscript/_internal/PolymodBaseClassMacro.hx
+++ b/polymod/hscript/_internal/PolymodBaseClassMacro.hx
@@ -215,6 +215,7 @@ class PolymodBaseClassMacro
             doesReturnVoid = (f.ret.toString() == 'Void');
           }
 
+          var oldPos:haxe.macro.Expr.Position = f.expr.pos;
           f.expr = macro
             {
               if (_asc != null && !_skipAscFrom.contains($v{fields[i].name}))
@@ -239,6 +240,8 @@ class PolymodBaseClassMacro
               // Fallback, call the original function.
               ${f.expr}
             };
+
+          f.expr.pos = oldPos;
 
         default:
           // Do nothing.


### PR DESCRIPTION
When I was making the macro, it seems I had forgotten to change the position of the expression back, making essentially every crashlog point to PolymodBaseClassMacro, even when it didn't make sense at all. This would make debugging nightmarish :fear: