### PR TITLE
Allow static fields to be read/set from an implicit context

### DIFF
--- a/polymod/hscript/_internal/Interp.hx
+++ b/polymod/hscript/_internal/Interp.hx
@@ -781,52 +781,57 @@ class Interp
       case EIdent(id):
         // Make sure setting superclass fields directly works.
         // Also ensures property functions are accounted for.
-        if (_proxy != null && _proxy.superHasField(id))
+        if (_proxy != null)
         {
-          if (Std.isOfType(_proxy.superClass, PolymodScriptClass))
+          if (_proxy.superHasField(id))
           {
-            var superClass:PolymodAbstractScriptClass = cast(_proxy.superClass, PolymodScriptClass);
-            return superClass.fieldWrite(id, v);
-          }
-
-          // Directly assign the value.
-          // This is needed because `assignValue` may sometimes be called from the constructor.
-          PolymodAbstractScriptClass.setClassObjectField(_proxy.superClass, id, v);
-          return v;
-        }
-
-        @:privateAccess
-        {
-          if (_proxy != null)
-          {
-            var decl = _proxy.findVar(id);
-            switch (decl?.set)
+            if (Std.isOfType(_proxy.superClass, PolymodScriptClass))
             {
-              case "set":
-                // Allow assigning to "null" only for local fields.
-                final setName = 'set_$id';
-                if (!_propTrack.exists(setName))
-                {
-                  _propTrack.set(setName, true);
-                  var out = _proxy.callFunction(setName, [v]);
-                  _propTrack.remove(setName);
-                  return (out == null) ? v : out;
-                }
-
-              case "never":
-                error(EInvalidPropSet(id));
-                return null;
-
-              case "null":
-                // If the property setter is "null", it can only be assigned on local fields.
-                // Thankfully, this is a local field!
-                // So we can just fallthrough to the default case.
+              var superClass:PolymodAbstractScriptClass = cast(_proxy.superClass, PolymodScriptClass);
+              return superClass.fieldWrite(id, v);
             }
 
-            if ((decl?.isfinal ?? false) && decl?.expr != null)
+            // Directly assign the value.
+            // This is needed because `assignValue` may sometimes be called from the constructor.
+            PolymodAbstractScriptClass.setClassObjectField(_proxy.superClass, id, v);
+            return v;
+          }
+          else
+          {
+            @:privateAccess
             {
-              error(EInvalidFinalSet(id));
-              return null;
+              var decl = _proxy.findVar(id);
+              if (decl != null)
+              {
+                switch (decl.set)
+                {
+                  case "set":
+                    // Allow assigning to "null" only for local fields.
+                    final setName = 'set_$id';
+                    if (!_propTrack.exists(setName))
+                    {
+                      _propTrack.set(setName, true);
+                      var out = _proxy.callFunction(setName, [v]);
+                      _propTrack.remove(setName);
+                      return (out == null) ? v : out;
+                    }
+
+                  case "never":
+                    error(EInvalidPropSet(id));
+                    return null;
+
+                  case "null":
+                    // If the property setter is "null", it can only be assigned on local fields.
+                    // Thankfully, this is a local field!
+                    // So we can just fallthrough to the default case.
+                }
+
+                if ((decl.isfinal ?? false) && decl.expr != null)
+                {
+                  error(EInvalidFinalSet(id));
+                  return null;
+                }
+              }
             }
           }
         }
@@ -836,7 +841,20 @@ class Interp
         {
           return error(EInvalidAccess(id));
         }
-        if (l == null) setVar(id, v);
+
+        if (l == null)
+        {
+          // Check if we're assigning the value of a static field inside the class itself.
+          // We check inside here to make sure we aren't overriding a local variable.
+          var fullClassName:String = getClassFullyQualifiedName();
+          if (PolymodScriptClass.hasScriptClassStaticField(fullClassName, id))
+          {
+            return PolymodScriptClass.setScriptClassStaticField(fullClassName, id, v);
+          }
+
+          // Fallback to just setting the var.
+          setVar(id, v);
+        }
         else
           l.r = v;
       case EField(e0, id):
@@ -1455,6 +1473,7 @@ class Interp
 
         var l = locals.get(id);
         if (l != null) return l.r;
+
         return resolve(id);
       case EVar(name, type, expression):
         declared.push({


### PR DESCRIPTION
Fixes issues:
[#341](https://github.com/FunkinCrew/polymod/issues/341)
[#7988](https://github.com/FunkinCrew/Funkin/issues/7988) (even tho it's a duplicate I did use it to test still so)

This PR fixes a bug where scripted classes would read their static fields not explicitly stated (ex. "StaticClass.helloWorld") as local variables.

<img width="456" height="617" alt="image" src="https://github.com/user-attachments/assets/2ec0d1b4-919d-4d26-9058-643a289b3fb6" />
<img width="361" height="196" alt="image" src="https://github.com/user-attachments/assets/063fd498-b19f-4e4a-8141-b94e786cd39b" />
<img width="496" height="112" alt="image" src="https://github.com/user-attachments/assets/b9252389-4c7c-40cb-948f-c7d2658a379d" />
