### PR TITLE
Allow `Std.isOfType` to check for scripted enums

### DIFF
--- a/polymod/hscript/_internal/Interp.hx
+++ b/polymod/hscript/_internal/Interp.hx
@@ -1271,6 +1271,9 @@ class Interp
         if (importedClass.enm != null) return importedClass.enm;
         if (importedClass.abs != null) return importedClass.abs;
 
+        var enumResult:Null<String> = PolymodEnum.tryResolve(importedClass.fullPath);
+        if (enumResult != null) return enumResult;
+
         // Resolve imported scripted classes.
         var result = PolymodStaticClassReference.tryBuild(importedClass.fullPath);
         if (result != null) return result;
@@ -1294,9 +1297,16 @@ class Interp
       if (getClassDecl().pkg != null && getClassDecl().pkg.length > 0)
       {
         var localClassId = getClassDecl().pkg.join('.') + "." + id;
+
+        var enumResult:Null<String> = PolymodEnum.tryResolve(localClassId);
+        if (enumResult != null) return enumResult;
+
         var result = PolymodStaticClassReference.tryBuild(localClassId);
         if (result != null) return result;
       }
+
+      var enumResult:Null<String> = PolymodEnum.tryResolve(id);
+      if (enumResult != null) return enumResult;
 
       // Try to retrieve a scripted class with this name in the base package.
       var result = PolymodStaticClassReference.tryBuild(id);

--- a/polymod/hscript/_internal/PolymodEnum.hx
+++ b/polymod/hscript/_internal/PolymodEnum.hx
@@ -36,6 +36,31 @@ class PolymodEnum
     this._args = args;
   }
 
+  /**
+   * Attempts to retrieve the full package of a scripted enum.
+   * @param id
+   */
+  public static function tryResolve(id:String):Null<String>
+  {
+    // `id` is a package.
+    if (id.indexOf('.') != -1)
+    {
+      // Enum exists so we can safely return the full package.
+      @:privateAccess
+      if (Interp._scriptEnumDescriptors.exists(id)) return id;
+    }
+
+    @:privateAccess
+    for (fullEnumName => val in Interp._scriptEnumDescriptors)
+    {
+      var splitPkg:Array<String> = fullEnumName.split('.');
+      var name:String = splitPkg[splitPkg.length - 1];
+
+      if (name == id) return fullEnumName;
+    }
+    return null;
+  }
+
   public static function clearScriptedEnums():Void
   {
     scriptInterp.clearScriptEnumDescriptors();

--- a/polymod/hscript/_internal/PolymodScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodScriptClass.hx
@@ -1,6 +1,7 @@
 package polymod.hscript._internal;
 
 import haxe.ds.ObjectMap;
+import polymod.hscript._internal.Expr.EnumDecl;
 import polymod.hscript._internal.Expr.ClassDecl;
 import polymod.hscript._internal.Expr.ClassImport;
 import polymod.hscript._internal.Expr.FieldDecl;
@@ -407,6 +408,17 @@ class PolymodScriptClass
   // Override version of Std.isOfType so we're able to test for scripted classes.
   public static function isOfType(v:Dynamic, t:Dynamic):Bool
   {
+    if (t is String && Interp._scriptEnumDescriptors.exists(t))
+    {
+      if (v is PolymodEnum)
+      {
+        var enumDecl:EnumDecl = v._e;
+
+        return Util.getFullEnumClass(enumDecl) == t;
+      }
+      return false;
+    }
+
     var typeClassDecl:ClassDecl = null;
     var typeFullName:String = '';
     if (t is PolymodStaticClassReference)

--- a/polymod/util/Util.hx
+++ b/polymod/util/Util.hx
@@ -776,4 +776,14 @@ class Util
     }
     return clsDecl.name;
   }
+
+  /**
+   * Retrieves the full qualified name for a scripted enum declaration.
+   * @param enumDecl The enum declaration.
+   * @return String
+   */
+  public static function getFullEnumClass(enumDecl:EnumDecl):String
+  {
+    return enumDecl.pkg != null ? '${enumDecl.pkg.join('.')}.${enumDecl}' : enumDecl.name;
+  }
 }


### PR DESCRIPTION
Fixes:
[#315](https://github.com/FunkinCrew/polymod/issues/315)

Completely overlooked this with my original Std.isOfType PR, so this PR allows to check for scripted enums along with scripted classes.