### PR TITLE
Implement wildcard imports

### DIFF
--- a/polymod/hscript/_internal/Expr.hx
+++ b/polymod/hscript/_internal/Expr.hx
@@ -307,6 +307,11 @@ typedef ClassImport =
    * Will be `null` if this is not an abstract class.
    */
   var ?abs:PolymodStaticAbstractReference;
+
+  /**
+   * Whether this import is a wildcard and we need to validate it for later.
+   */
+  var ?wildcard:Bool;
 }
 
 typedef EnumDecl =

--- a/polymod/hscript/_internal/Interp.hx
+++ b/polymod/hscript/_internal/Interp.hx
@@ -632,6 +632,10 @@ class Interp
     // Clear the script class descriptors.
     _scriptClassDescriptors.clear();
 
+    // We clear this field so it later re-generates when validating imports.
+    @:privateAccess
+    PolymodScriptClass._scriptClassesByPackage = null;
+
     // Also clear the imports from the import.hx files.
     _scriptClassImports.clear();
     _scriptClassUsings.clear();
@@ -1369,7 +1373,7 @@ class Interp
    * @param ignoreEnums Whether to skip resolving enums. Used when resolving a `using` import.
    * @return `false` if this import was blacklisted, otherwise always `true`.
    */
-  function resolveImportedClass(importedClass:ClassImport, ignoreEnums:Bool = false):Bool
+  static function resolveImportedClass(importedClass:ClassImport, ignoreEnums:Bool = false):Bool
   {
     // The path without the possibly included module name, which resolve methods disregard.
     final modulelessPath:String = importedClass.pkg.slice(0, -1).concat([importedClass.name]).join('.');
@@ -2616,60 +2620,83 @@ class Interp
       {
         case DPackage(path):
           pkg = path;
-        case DImport(path, _, name):
-          var clsName:String = name != null ? name : path[path.length - 1];
-
-          if (imports.exists(clsName))
+        case DImport(path, star, name):
+          if (star)
           {
-            if (imports.get(clsName) == null)
-            {
-              Polymod.error(SCRIPTED_CLASS_BLACKLISTED_MODULE, 'Scripted class ${clsName} is blacklisted and cannot be used in scripts.', SCRIPT_RUNTIME);
-            }
-            else
-            {
-              Polymod.warning(SCRIPTED_CLASS_REDUNDANT_IMPORT, 'Scripted class ${clsName} has already been imported.', SCRIPT_RUNTIME);
-            }
-            continue;
-          }
+            if (path.length == 0) continue; // Disallow wildcards imports with no package.
+            if ((importsToValidate.get(path.join('.'))?.wildcard) ?? false) continue; // Don't add duplicate wildcards.
 
-          var importedClass:ClassImport = {
-            name: clsName,
-            pkg: path.slice(0, path.length - 1),
-            fullPath: path.join("."),
-            cls: null,
-            enm: null,
-            abs: null
-          };
+            var wildcardImport:ClassImport =
+            {
+              name: null,
+              pkg: null,
+              fullPath: path.join('.'),
+              wildcard: star
+            }
 
-          if (_scriptEnumDescriptors.exists(importedClass.fullPath))
-          {
-            // do nothing
+            if (isImportFile)
+            {
+              registerImportForPackage(pkg, wildcardImport);
+              continue;
+            }
+
+            // We'll leave this as an import to be validated later.
+            importsToValidate.set(wildcardImport.fullPath, wildcardImport);
           }
           else
           {
-            if (resolveImportedClass(importedClass) && importedClass.cls == null && importedClass.enm == null && importedClass.abs == null)
-            {
-              if (isImportFile)
-              {
-                registerImportForPackage(pkg, importedClass);
-                continue;
-              }
+            var clsName:String = name != null ? name : path[path.length - 1];
 
-              // Polymod.error(SCRIPT_CLASS_MODULE_NOT_FOUND, 'Could not import class ${importedClass.fullPath}', SCRIPT_RUNTIME);
-              // this could be a scripted class or enum that hasn't been registered yet
-              importsToValidate.set(importedClass.name, importedClass);
+            if (imports.exists(clsName))
+            {
+              if (imports.get(clsName) == null)
+              {
+                Polymod.error(SCRIPTED_CLASS_BLACKLISTED_MODULE, 'Scripted class ${clsName} is blacklisted and cannot be used in scripts.', SCRIPT_RUNTIME);
+              }
+              else
+              {
+                Polymod.warning(SCRIPTED_CLASS_REDUNDANT_IMPORT, 'Scripted class ${clsName} has already been imported.', SCRIPT_RUNTIME);
+              }
               continue;
             }
-          }
 
-          if (isImportFile)
-          {
-            registerImportForPackage(pkg, importedClass);
-            continue;
-          }
+            var importedClass:ClassImport =
+            {
+              name: clsName,
+              pkg: path.slice(0, path.length - 1),
+              fullPath: path.join(".")
+            };
 
-          // Polymod.debug('Imported class ${importedClass.name} from ${importedClass.fullPath}');
-          imports.set(importedClass.name, importedClass);
+            if (_scriptEnumDescriptors.exists(importedClass.fullPath))
+            {
+              // do nothing
+            }
+            else
+            {
+              if (resolveImportedClass(importedClass) && importedClass.cls == null && importedClass.enm == null && importedClass.abs == null)
+              {
+                if (isImportFile)
+                {
+                  registerImportForPackage(pkg, importedClass);
+                  continue;
+                }
+
+                // Polymod.error(SCRIPT_CLASS_MODULE_NOT_FOUND, 'Could not import class ${importedClass.fullPath}', SCRIPT_RUNTIME);
+                // this could be a scripted class or enum that hasn't been registered yet
+                importsToValidate.set(importedClass.name, importedClass);
+                continue;
+              }
+            }
+
+            if (isImportFile)
+            {
+              registerImportForPackage(pkg, importedClass);
+              continue;
+            }
+
+            // Polymod.debug('Imported class ${importedClass.name} from ${importedClass.fullPath}');
+            imports.set(importedClass.name, importedClass);
+          }
         case DUsing(path):
           var clsName = path.join('.');
 
@@ -2827,7 +2854,13 @@ class Interp
       {
         if (!pkg.startsWith(key) && key.length != 0) continue;
 
-        for (imp in imps) cls.imports.set(imp.name, imp);
+        for (imp in imps)
+        {
+          if (imp.wildcard)
+            importWildcard(cls, imp);
+          else
+            cls.imports.set(imp.name, imp);
+        }
       }
 
       for (key => uses in _scriptClassUsings)
@@ -2840,6 +2873,12 @@ class Interp
       // Add the scripted imports.
       for (key => imp in cls.importsToValidate)
       {
+        if (imp.wildcard)
+        {
+          importWildcard(cls, imp);
+          continue;
+        }
+
         if (_scriptClassDescriptors.exists(imp.fullPath))
         {
           cls.imports.set(key, imp);
@@ -2909,6 +2948,59 @@ class Interp
           case _:
         }
       }
+    }
+  }
+
+  static function importWildcard(cls:ClassDecl, wildcardImport:ClassImport):Void
+  {
+    var pack:String = wildcardImport.fullPath;
+    var classesToImport:Array<String> = [];
+
+    if (PolymodScriptClass.baseClassesByPackage.exists(pack))
+      classesToImport = classesToImport.concat(PolymodScriptClass.baseClassesByPackage.get(pack));
+
+    if (PolymodScriptClass.scriptClassesByPackage.exists(pack))
+      classesToImport = classesToImport.concat(PolymodScriptClass.scriptClassesByPackage.get(pack));
+
+    if (classesToImport.length == 0)
+      return;
+
+    for (clsName in classesToImport)
+    {
+      var name:String = clsName.substr(pack.length + 1);
+
+      if (cls.imports.exists(name))
+      {
+        if (cls.imports.get(name) == null)
+        {
+          Polymod.error(SCRIPTED_CLASS_BLACKLISTED_MODULE, 'Scripted class ${name} is blacklisted and cannot be used in scripts.', SCRIPT_RUNTIME);
+        }
+        else
+        {
+          Polymod.warning(SCRIPTED_CLASS_REDUNDANT_IMPORT, 'Scripted class ${name} has already been imported.', SCRIPT_RUNTIME);
+        }
+        continue;
+      }
+
+      var classImport:ClassImport = {
+        name: name,
+        pkg: pack.split('.'),
+        fullPath: clsName,
+        cls: null,
+        abs: null,
+        enm: null,
+      }
+
+      if (resolveImportedClass(classImport) && classImport.cls == null && classImport.enm == null && classImport.abs == null)
+      {
+        // Check if this is a scripted class.
+        if (_scriptClassDescriptors.exists(classImport.fullPath) || _scriptEnumDescriptors.exists(classImport.fullPath))
+        {
+          cls.imports.set(classImport.name, classImport);
+          continue;
+        }
+      }
+      cls.imports.set(classImport.name, classImport);
     }
   }
 

--- a/polymod/hscript/_internal/PolymodScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodScriptClass.hx
@@ -145,6 +145,58 @@ class PolymodScriptClass
     return _typedefs;
   }
 
+  static var _baseClassesByPackage:Map<String, Array<String>>;
+
+  /**
+   * Defines a list of classes that each package contains.
+   * Compiled at runtime through a macro to then be stored here.
+   */
+  public static var baseClassesByPackage(get, never):Map<String, Array<String>>;
+
+  static function get_baseClassesByPackage():Map<String, Array<String>>
+  {
+    if (_baseClassesByPackage == null)
+    {
+      _baseClassesByPackage = new Map<String, Array<String>>();
+      for (pkg => cls in PolymodScriptClassMacro.listPackagesList())
+      {
+        _baseClassesByPackage.set(pkg, cls);
+      }
+    }
+    return _baseClassesByPackage;
+  }
+
+  static var _scriptClassesByPackage:Map<String, Array<String>>;
+
+  /**
+   * Defines a list of scripted classes that each package contains.
+   * Reset everytime scripts are re-registered.
+   */
+  public static var scriptClassesByPackage(get, never):Map<String, Array<String>>;
+
+  static function get_scriptClassesByPackage():Map<String, Array<String>>
+  {
+    if (_scriptClassesByPackage == null)
+    {
+      _scriptClassesByPackage = new Map<String, Array<String>>();
+
+      for (cls in Interp._scriptClassDescriptors)
+      {
+        if (cls.pkg == null || cls.pkg.length == 0) continue;
+
+        var pack:String = cls.pkg.join('.');
+        var list:Array<String> = _scriptClassesByPackage.get(pack) ?? [];
+        var fullPath:String = Util.getFullClassName(cls);
+
+        if (!list.contains(fullPath))
+          list.push(fullPath);
+
+        _scriptClassesByPackage.set(cls.pkg.join('.'), list);
+      }
+    }
+    return _scriptClassesByPackage;
+  }
+
   /**
    * Register a scripted class by retrieving the script from the given path.
    *

--- a/polymod/hscript/_internal/PolymodScriptClassMacro.hx
+++ b/polymod/hscript/_internal/PolymodScriptClassMacro.hx
@@ -73,12 +73,29 @@ class PolymodScriptClassMacro
     return macro polymod.hscript._internal.PolymodScriptClassMacro.fetchTypedefs();
   }
 
+  /**
+   * @return An expression containing a mapping of each package to what classes are in said package.
+   */
+  public static macro function listPackagesList():ExprOf<Map<String, Array<String>>>
+  {
+    if (!onGenerateCallbackRegistered)
+    {
+      onGenerateCallbackRegistered = true;
+      haxe.macro.Context.onGenerate(onGenerate);
+    }
+
+    return macro polymod.hscript._internal.PolymodScriptClassMacro.fetchPackagesList();
+  }
+
   #if macro
   static var onGenerateCallbackRegistered:Bool = false;
   static var onAfterTypingCallbackRegistered:Bool = false;
+  static var packageEntries:Map<String, Array<String>> = [];
 
   static function onGenerate(allTypes:Array<haxe.macro.Type>)
   {
+    packageEntries.clear();
+
     // Reset these, since onGenerate persists across multiple builds.
     var hscriptedClassType:ClassType = MacroUtil.getClassType('polymod.hscript.HScriptedClass');
 
@@ -96,7 +113,8 @@ class PolymodScriptClassMacro
           // Parse classes to check if they are `HScriptedClass` implementations, for processing later.
 
           var classType:ClassType = t.get();
-          var classPath:String = '${classType.pack.concat([classType.name]).join(".")}';
+          var classPack:String = classType.pack.join('.');
+          var classPath:String = t.toString();
 
           if (classType.isInterface)
           {
@@ -113,6 +131,7 @@ class PolymodScriptClassMacro
             hscriptedClassEntries.push(entryData);
           }
 
+          addPackageClass(classPack, classPath);
         case TType(t, _params):
           var typedefPath:String = t.toString();
           var typedefTarget:Type = Context.followWithAbstracts(type);
@@ -135,7 +154,7 @@ class PolymodScriptClassMacro
               var entryData = [typedefPath, targetPath];
 
               typedefEntries.push(entryData);
-
+              addPackageClass(t.get().pack.join('.'), targetPath);
             case TEnum(t, _params):
               var targetEnum:EnumType = t.get();
               var targetEnumPath:String = '${targetEnum.pack.concat([targetEnum.name]).join(".")}';
@@ -143,7 +162,7 @@ class PolymodScriptClassMacro
               var entryData = [typedefPath, targetEnumPath];
 
               typedefEntries.push(entryData);
-
+              addPackageClass(targetEnum.pack.join('.'), targetEnumPath);
             case TInst(t, _params):
               var targetClass:ClassType = t.get();
               var targetClassPath:String = '${targetClass.pack.concat([targetClass.name]).join(".")}';
@@ -151,7 +170,7 @@ class PolymodScriptClassMacro
               var entryData = [typedefPath, targetClassPath];
 
               typedefEntries.push(entryData);
-
+              addPackageClass(targetClass.pack.join('.'), targetClassPath);
             default:
               // Unknown typedef target type?
               trace('TYPEDEF: ${typedefPath} -> ${typedefTarget}');
@@ -162,6 +181,7 @@ class PolymodScriptClassMacro
 
           var abstractPath:String = t.toString();
           var abstractType = t.get();
+          var abstractPack:String = abstractType.pack.join('.');
           var abstractImpl = abstractType.impl?.get();
 
           if (abstractImpl == null)
@@ -189,6 +209,7 @@ class PolymodScriptClassMacro
           ];
 
           abstractImplEntries.push(entryData);
+          addPackageClass(abstractPack, abstractPath);
         default:
           continue;
       }
@@ -197,7 +218,8 @@ class PolymodScriptClassMacro
     var metaData = {
       hscriptedClasses: hscriptedClassEntries,
       abstractImpls: abstractImplEntries,
-      typedefs: typedefEntries
+      typedefs: typedefEntries,
+      packages: packageEntries
     };
 
     var metaDataHXSF = haxe.Serializer.run(metaData);
@@ -465,6 +487,20 @@ class PolymodScriptClassMacro
       Context.info('PolymodScriptClassMacro: Created ${count} custom abstract implementations in ${duration} sec.', Context.currentPos());
     }
   }
+
+  static function addPackageClass(pack:String, cls:String):Void
+  {
+    if (pack.indexOf('.') == -1) return; // Don't store classes without a package.
+    if (pack.startsWith('polymod.')) return; // Exclude polymod classes.
+    if (cls.endsWith('_Impl_')) return; // Exclude implementation classes.
+
+    var list:Array<String> = packageEntries.get(pack) ?? [];
+    if (!list.contains(cls))
+    {
+      list.push(cls);
+      packageEntries.set(pack, list);
+    }
+  }
   #end
 
   public static function fetchHScriptedClasses():Map<String, Class<Dynamic>>
@@ -584,6 +620,17 @@ class PolymodScriptClassMacro
     {
       throw 'No typedefs found in PolymodScriptClassMacro!';
     }
+  }
+
+  public static function fetchPackagesList():Map<String, Array<String>>
+  {
+    var metaData = fetchMetadata();
+
+    if (metaData.packages != null)
+    {
+      return metaData.packages;
+    }
+    return [];
   }
 
   static var _metadata:Dynamic = null;


### PR DESCRIPTION
This PR implements support for doing wildcard imports `(import .*)`

## How it works
Through editing the `PolymodScriptClassMacro` class, the library maps each class to its given package, with specific exclusions (Doesn't include polymod classes for obvious reasons, no generated `_Impl_` classes, etc.), this is how it works for base classes.

The import is marked to be validated later, and when the library attempts to, the wildcard import concatenates a list of classes to try importing. This importing method is the exact same as if the classes were to be regularly imported so blacklisting is still done.

These imports can also be done via an `import.hxc` file if you must.