### PR TITLE
[BUGFIX] Implement proper Asset Redirection in `LimeCoreLibrary.loadText`

### DIFF
--- a/polymod/backends/LimeBackend.hx
+++ b/polymod/backends/LimeBackend.hx
@@ -1525,6 +1525,16 @@ class LimeCoreLibrary extends LimeAssetLibrary
 
   public override function loadText(id:String):Future<String>
   {
+    var redirectId:String = buildRedirectId(id);
+    if (polymodLibrary.fileSystem.exists(redirectId))
+    {
+      var bytesFuture = polymodLibrary.fileSystem.loadFileBytes(redirectId);
+      var textFuture = bytesFuture.then((bytes:Bytes) -> {
+        return Future.withValue(bytes.toString());
+      });
+      return textFuture;
+    }
+
     return fallback.loadText(id);
   }
 


### PR DESCRIPTION
## Linked Issues
FunkinCrew/Funkin#8059

## What does this PR do?
This PR implements proper asset redirection in `LimeCoreLibrary.loadText`, which caused the core asset redirection feature to never work with asynchronous text loading.

The Funkin' issue above is linked due to the `REDIRECT_ASSETS_FOLDER` feature flag using core asset redirection.