### PR TITLE
[ENHANCMENT + BUGFIX] Fix full package/class path resolution in scripted classes

### DIFF
--- a/polymod/hscript/_internal/Interp.hx
+++ b/polymod/hscript/_internal/Interp.hx
@@ -1543,11 +1543,32 @@ class Interp
           catch (err:Dynamic)
           {
             var fullPath = getFullIdentPath(e);
-            if (PolymodScriptClass.importOverrides.exists(fullPath) 
-                && PolymodScriptClass.importOverrides.get(fullPath) == null)
+            if (fullPath != null)
             {
               fullPath += '.' + f;
-              return resolve(fullPath);
+
+              var pathParts = fullPath.split('.');
+              var candidateImport:ClassImport =
+              {
+                name: pathParts[pathParts.length - 1],
+                pkg: pathParts.slice(0, pathParts.length - 1),
+                fullPath: fullPath
+              };
+
+              if (!resolveImportedClass(candidateImport))
+              {
+                error(EBlacklistedModule(fullPath));
+              }
+
+              if (candidateImport.cls != null) return candidateImport.cls;
+              if (candidateImport.pkg != null) return candidateImport.pkg;
+              if (candidateImport.abs != null) return candidateImport.abs;
+
+              var enumResult = PolymodEnum.tryResolve(fullPath);
+              if (enumResult != null) return enumResult;
+
+              var scriptedCls = PolymodStaticClassReference.tryBuild(fullPath);
+              if (scriptedCls != null) return scriptedCls;
             }
             throw err;
           }

--- a/polymod/hscript/_internal/Interp.hx
+++ b/polymod/hscript/_internal/Interp.hx
@@ -1534,6 +1534,24 @@ class Interp
         {
           return new PolymodEnum(_scriptEnumDescriptors.get(name), f, []);
         }
+        if (name == null)
+        {
+          try
+          {
+            return get(expr(e), f);
+          }
+          catch (err:Dynamic)
+          {
+            var fullPath = getFullIdentPath(e);
+            if (PolymodScriptClass.importOverrides.exists(fullPath) 
+                && PolymodScriptClass.importOverrides.get(fullPath) == null)
+            {
+              fullPath += '.' + f;
+              return resolve(fullPath);
+            }
+            throw err;
+          }
+        }
         return get(expr(e), f);
       case EBinop(op, e1, e2):
         var fop = binops.get(op);
@@ -2169,6 +2187,21 @@ class Interp
     {
       case EIdent(v):
         return v;
+      default:
+        return null;
+    }
+  }
+
+  function getFullIdentPath(e:Expr):Null<String>
+  {
+    switch (Tools.expr(e))
+    {
+      case EIdent(id):
+        return id;
+      case EField(e2, f2):
+        var base = getFullIdentPath(e2);
+        if (base == null) return null;
+        return base + '.' + f2;
       default:
         return null;
     }


### PR DESCRIPTION
Closes #469

## Description
This PR fixes scripted classes not being able to  reference a class by its full package, unless being imported initially.
### Changes
- Added `getFullIdentPath` in `Interp.hx` to flatten field chains (e.g. `a.b.c`) into dotted strings.
- Added a fallback: if dotted chain lookup fails, try resolving the entire path as a fully-qualified class or enum (`Type.resolveClass` / `Type.resolveEnum`) before throwing the original error.
	- NOTE: No behavior changes for existing imports, local variables, or single-segment access.