### PR TITLE
Remove now unused code for HScripted class redirection

### DIFF
--- a/polymod/hscript/_internal/PolymodScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodScriptClass.hx
@@ -230,31 +230,6 @@ class PolymodScriptClass
    * STATIC PROPERTIES
    */
   /**
-   * Define a list of script classes to override the default behavior of Polymod.
-   * For example, script classes should import `ScriptedSprite` instead of `Sprite`.
-   */
-  public static var scriptClassOverrides(get, never):Map<String, Class<Dynamic>>;
-
-  static var _scriptClassOverrides:Map<String, Class<Dynamic>> = null;
-
-  static function get_scriptClassOverrides():Map<String, Class<Dynamic>>
-  {
-    if (_scriptClassOverrides == null)
-    {
-      _scriptClassOverrides = new Map<String, Class<Dynamic>>();
-
-      var baseScriptClassOverrides:Map<String, Class<Dynamic>> = PolymodScriptClassMacro.listHScriptedClasses();
-
-      for (key => value in baseScriptClassOverrides)
-      {
-        _scriptClassOverrides.set(key, value);
-      }
-    }
-
-    return _scriptClassOverrides;
-  }
-
-  /**
    * Define a list of all the abstracts we have available at compile time,
    * and map them to internal implementation classes.
    * We use this to access the functions of these abstracts.
@@ -718,10 +693,6 @@ class PolymodScriptClass
         {
           targetClass = null;
         }
-        else if (scriptClassOverrides.exists(clsPath))
-        {
-          targetClass = scriptClassOverrides.get(clsPath);
-        }
         #if POLYMOD_CPPIA
         else if (PolymodCppiaClassReference.hasCppiaClass(clsPath))
         {
@@ -860,17 +831,8 @@ class PolymodScriptClass
     {
       var clsToCreate:Class<Dynamic> = null;
 
-      if (scriptClassOverrides.exists(fullExtendString))
-      {
-        clsToCreate = scriptClassOverrides.get(fullExtendString);
-
-        if (clsToCreate == null)
-        {
-          _interp.error(EClassUnresolvedSuperclass(fullExtendString, 'WHY?'));
-        }
-      }
       #if POLYMOD_CPPIA
-      else if (PolymodCppiaClassReference.hasCppiaClass(fullExtendString))
+      if (PolymodCppiaClassReference.hasCppiaClass(fullExtendString))
       {
         clsToCreate = PolymodCppiaClassReference.getCppiaClass(fullExtendString);
 
@@ -879,8 +841,9 @@ class PolymodScriptClass
           _interp.error(EClassUnresolvedSuperclass(fullExtendString, 'no loaded compiled script provides it'));
         }
       }
+      else
       #end
-      else if (_c.imports.exists(extendString))
+      if (_c.imports.exists(extendString))
       {
         clsToCreate = _c.imports.get(extendString).cls;
 

--- a/polymod/hscript/_internal/PolymodScriptClassMacro.hx
+++ b/polymod/hscript/_internal/PolymodScriptClassMacro.hx
@@ -5,14 +5,13 @@ import haxe.macro.Context;
 import haxe.macro.Expr;
 import haxe.macro.Type;
 import haxe.macro.Type.ClassType;
-import polymod.util.MacroUtil;
 #end
 
 using StringTools;
 
 /**
- * Provides a macro which, after types are generated, populates a list of classes which extend `polymod.hscript.HScriptedClass`.
- * We have to do weird shenanigans to make the data accessible at runtime though.
+ * Provides a macro which, generates implementations of types so that they can be usable by HScript.
+ * We have to do weird shenanigans to make them accessible at runtime though.
  */
 class PolymodScriptClassMacro
 {
@@ -20,23 +19,6 @@ class PolymodScriptClassMacro
    * The name for the Haxe resource that stores Generation Metadata.
    */
   static inline final METADATA_RESOURCE_NAME:String = 'PolymodScriptClassMacro_METADATA';
-
-  /**
-   * Returns a `Map<String, Class<Dynamic>>` which maps superclass paths to scripted classes.
-   * So `class ScriptedStage extends Stage implements HScriptable` will be `"Stage" -> ScriptedStage`
-   *
-   * @return An expression containing a map of superclasses to their scripted classes
-   */
-  public static macro function listHScriptedClasses():ExprOf<Map<String, Class<Dynamic>>>
-  {
-    if (!onGenerateCallbackRegistered)
-    {
-      onGenerateCallbackRegistered = true;
-      haxe.macro.Context.onGenerate(onGenerate);
-    }
-
-    return macro polymod.hscript._internal.PolymodScriptClassMacro.fetchHScriptedClasses();
-  }
 
   /**
    * @return An expression containing a map of abstract classes to their implementations
@@ -97,9 +79,6 @@ class PolymodScriptClassMacro
     packageEntries.clear();
 
     // Reset these, since onGenerate persists across multiple builds.
-    var hscriptedClassType:ClassType = MacroUtil.getClassType('polymod.hscript.HScriptedClass');
-
-    var hscriptedClassEntries:Array<Array<String>> = [];
     var abstractImplEntries:Array<Array<String>> = [];
     var typedefEntries:Array<Array<String>> = [];
 
@@ -115,21 +94,6 @@ class PolymodScriptClassMacro
           var classType:ClassType = t.get();
           var classPack:String = classType.pack.join('.');
           var classPath:String = t.toString();
-
-          if (classType.isInterface)
-          {
-            // Ignore interfaces.
-          }
-          else if (MacroUtil.implementsInterface(classType, hscriptedClassType))
-          {
-            var superClass:Null<ClassType> = classType.superClass != null ? classType.superClass.t.get() : null;
-
-            if (superClass == null) throw 'No superclass for ' + classPath;
-
-            var superClassPath:String = '${superClass.pack.concat([superClass.name]).join(".")}';
-            var entryData = [superClassPath, classPath];
-            hscriptedClassEntries.push(entryData);
-          }
 
           addPackageClass(classPack, classPath);
         case TType(t, _params):
@@ -216,7 +180,6 @@ class PolymodScriptClassMacro
     }
 
     var metaData = {
-      hscriptedClasses: hscriptedClassEntries,
       abstractImpls: abstractImplEntries,
       typedefs: typedefEntries,
       packages: packageEntries
@@ -230,8 +193,7 @@ class PolymodScriptClassMacro
     var duration:Float = endTime - startTime;
 
     Context.info('PolymodScriptClassMacro: '
-      + 'Registered ${hscriptedClassEntries.length} HScriptedClasses, '
-      + '${abstractImplEntries.length} abstract impls, '
+      + 'Registered ${abstractImplEntries.length} abstract impls, '
       + '${typedefEntries.length} typedefs '
       + 'in ${duration} sec.',
       Context.currentPos());
@@ -265,7 +227,8 @@ class PolymodScriptClassMacro
             var abstractImplStatics:Array<ClassField> = abstractImplType.statics.get();
 
             var isAbstractImplExtern = abstractImplType.isExtern;
-            if (isAbstractImplExtern) {
+            if (isAbstractImplExtern)
+            {
               // TODO: abstract externs tend to be problematic and cause lots of build errors,
               // so we just skip them for now. If you can find a fix, feel free.
               continue;
@@ -503,38 +466,6 @@ class PolymodScriptClassMacro
   }
   #end
 
-  public static function fetchHScriptedClasses():Map<String, Class<Dynamic>>
-  {
-    var metaData = fetchMetadata();
-
-    if (metaData.hscriptedClasses != null)
-    {
-      var result:Map<String, Class<Dynamic>> = [];
-
-      // Each element is formatted as `[superClassPath, classPath]`.
-
-      var hscriptedClasses:Array<Array<String>> = cast metaData.hscriptedClasses;
-      for (element in hscriptedClasses)
-      {
-        if (element.length != 2)
-        {
-          throw 'Malformed element in hscriptedClasses: ' + element;
-        }
-
-        var superClassPath:String = element[0];
-        var classPath:String = element[1];
-        var classType:Class<Dynamic> = cast Type.resolveClass(classPath);
-        result.set(superClassPath, classType);
-      }
-
-      return result;
-    }
-    else
-    {
-      throw 'No hscriptedClasses found in PolymodScriptClassMacro!';
-    }
-  }
-
   public static function fetchAbstractImpls():Map<String, AbstractImplEntry>
   {
     var metaData = fetchMetadata();
@@ -634,6 +565,7 @@ class PolymodScriptClassMacro
   }
 
   static var _metadata:Dynamic = null;
+
   static function fetchMetadata():Dynamic
   {
     if (_metadata != null) return _metadata;


### PR DESCRIPTION
Since now (nearly) all classes are now scriptable, these parts of the code do pretty much nothing.
I'm iffy on whether we should get rid of the `HScriptedClass` interface since it also serves no purpose now.