### PR TITLE
[FEATURE] Script Class Blacklisting

### DIFF
--- a/polymod/Polymod.hx
+++ b/polymod/Polymod.hx
@@ -1314,6 +1314,35 @@ class Polymod
 
     PolymodScriptClass.bumpBlacklistGeneration();
   }
+
+  /**
+   * When a scripted class defines an import for another scripted class, you can blacklist it from being imported.
+   * @param importPath The full import path to blacklist, as a string.
+   */
+  public static function blacklistScriptClassImport(importPath:String):Void
+  {
+    PolymodScriptClass.blacklistedScriptClasses.push(importPath);
+  }
+
+  /**
+   * When an instance field from a script calss is being called, you can blacklist it from being called.
+   * @param cls The class type with the fields.
+   * @param fields The instance fields you want to blacklist.
+   */
+  public static function blacklistScriptClassInstanceFields(cls:String, fields:Array<String>):Void
+  {
+    PolymodScriptClass.blacklistedScriptClassInstanceFields.set(cls, fields);
+  }
+
+  /**
+   * When a static field from a script class is being called, you can blacklist it from being used.
+   * @param cls The class type with the fields.
+   * @param fields The static fields you want to blacklist.
+   */
+  public static function blacklistScriptClassStaticFields(cls:String, fields:Array<String>):Void
+  {
+    PolymodScriptClass.blacklistedScriptClassStaticFields.set(cls, fields);
+  }
 }
 
 /**

--- a/polymod/hscript/_internal/Interp.hx
+++ b/polymod/hscript/_internal/Interp.hx
@@ -302,7 +302,16 @@ class Interp
     }
     #end
 
-    else if (Std.isOfType(o, PolymodStaticAbstractReference))
+    // Check for script class blacklisted fields.
+    var oScriptCls:Null<String> = Util.getScriptClassName(o);
+    if (oScriptCls != null && ((PolymodScriptClass.blacklistedScriptClassStaticFields.get(oScriptCls)?.contains(f) ?? false)
+      || (PolymodScriptClass.blacklistedScriptClassInstanceFields.get(oScriptCls)?.contains(f) ?? false)))
+    {
+      error(EBlacklistedField(f));
+      return null;
+    }
+
+    if (Std.isOfType(o, PolymodStaticAbstractReference))
     {
       var ref:PolymodStaticAbstractReference = cast(o, PolymodStaticAbstractReference);
       return ref.callFunction(f, args);
@@ -556,6 +565,31 @@ class Interp
       return null;
     }
   }
+
+
+  /**
+   * Given a class declaration, fetches all fields with the `@:blacklisted` metadata and adds it to the script class blacklist.
+   * @param cls The class declaration.
+   */
+  static function registerScriptClassBlacklist(cls:ClassDecl):Void
+  {
+    var clsName:String = Util.getFullClassName(cls);
+    if (cls.meta.length > 0 && cls.meta.findIndex((m) -> return m.name == ':blacklisted') != -1)
+    {
+      Polymod.blacklistScriptClassImport(clsName);
+    }
+
+    // Filter fields to see which have the `@:blacklisted` metadata.
+    var staticFields:Array<String> = [for (field in cls.staticFields.filter((f) -> f.meta.length > 0 && f.meta.findIndex((m) -> return m.name == ':blacklisted') != -1)) field.name];
+    var instanceFields:Array<String> = [for (field in cls.fields.filter((f) -> f.meta.length > 0 && f.meta.findIndex((m) -> return m.name == ':blacklisted') != -1)) field.name];
+
+    if (staticFields.length > 0)
+      Polymod.blacklistScriptClassStaticFields(clsName, staticFields);
+
+    if (instanceFields.length > 0)
+      Polymod.blacklistScriptClassInstanceFields(clsName, instanceFields);
+  }
+
 
   static function registerScriptClass(c:ClassDecl)
   {
@@ -2716,6 +2750,15 @@ class Interp
       return null;
     }
 
+    // Check for script class blacklisted functions.
+    var oScriptCls:Null<String> = Util.getScriptClassName(o);
+    if (oScriptCls != null && ((PolymodScriptClass.blacklistedScriptClassStaticFields.get(oScriptCls)?.contains(f) ?? false)
+      || (PolymodScriptClass.blacklistedScriptClassInstanceFields.get(oScriptCls)?.contains(f) ?? false)))
+    {
+      error(EBlacklistedField(f));
+      return null;
+    }
+
     // If not, check if it is a blacklisted instance field.
     if (oCls.length > 0 && oCls != 'Object')
     {
@@ -3128,6 +3171,7 @@ class Interp
             isExtern: c.isExtern,
             staticFields: staticFields,
           };
+          registerScriptClassBlacklist(classDecl);
           registerScriptClass(classDecl);
         case DInterface(i):
           if (isImportFile) continue;
@@ -3341,6 +3385,19 @@ class Interp
 
   public static function validateImports():Void
   {
+    function tryImport(cls:ClassDecl, clsImport:ClassImport):Void
+    {
+      if (PolymodScriptClass.blacklistedScriptClasses.contains(clsImport.fullPath))
+      {
+        // Set as `null` so it's registered as blacklisted.
+        cls.imports.set(clsImport.name, null);
+      }
+      else
+      {
+        cls.imports.set(clsImport.name, clsImport);
+      }
+    }
+
     for (cls in _scriptClassDescriptors)
     {
       var clsPath = Util.getFullClassName(cls);
@@ -3360,7 +3417,7 @@ class Interp
 
         if ((imp.pkg?.length ?? 0) == 0)
         {
-          cls.imports.set(imp.name, classImport);
+          tryImport(cls, classImport);
           continue;
         }
 
@@ -3368,7 +3425,7 @@ class Interp
         var fullPackage:String = hasPackage ? cls.pkg.join(".") + "." : "";
         if (hasPackage && clsPath.indexOf(fullPackage) == 0)
         {
-          cls.imports.set(imp.name, classImport);
+          tryImport(cls, classImport);
         }
       }
 
@@ -3417,7 +3474,7 @@ class Interp
             }
           }
           else
-            cls.imports.set(imp.name, imp);
+            tryImport(cls, imp);
         }
       }
 
@@ -3443,7 +3500,7 @@ class Interp
         if (PolymodScriptClass.interfaceImpls.exists(imp.fullPath) || _scriptInterfaceDescriptors.exists(imp.fullPath) ||
           _scriptClassDescriptors.exists(imp.fullPath) || _scriptEnumDescriptors.exists(imp.fullPath))
         {
-          cls.imports.set(key, imp);
+          tryImport(cls, imp);
           continue;
         }
 
@@ -3559,6 +3616,11 @@ class Interp
         // Check if this is a scripted class.
         if (_scriptClassDescriptors.exists(classImport.fullPath) || _scriptEnumDescriptors.exists(classImport.fullPath))
         {
+          if (PolymodScriptClass.blacklistedScriptClasses.contains(classImport.fullPath) && !_scriptEnumDescriptors.exists(classImport.fullPath))
+          {
+            validImports.set(classImport.name, null);
+            continue;
+          }
           validImports.set(classImport.name, classImport);
           continue;
         }

--- a/polymod/hscript/_internal/Interp.hx
+++ b/polymod/hscript/_internal/Interp.hx
@@ -2750,7 +2750,7 @@ class Interp
       return null;
     }
 
-    // Check for script class blacklisted functions.
+    // Check for script class blacklisted fields.
     var oScriptCls:Null<String> = Util.getScriptClassName(o);
     if (oScriptCls != null && ((PolymodScriptClass.blacklistedScriptClassStaticFields.get(oScriptCls)?.contains(f) ?? false)
       || (PolymodScriptClass.blacklistedScriptClassInstanceFields.get(oScriptCls)?.contains(f) ?? false)))
@@ -2891,6 +2891,15 @@ class Interp
         Polymod.error(SCRIPTED_CLASS_BLACKLISTED_FIELD, 'Class field ${oCls}.${f} is blacklisted and cannot be used in scripts.', SCRIPT_RUNTIME);
         return null;
       }
+    }
+
+    // Check for script class blacklisted.
+    var oScriptCls:Null<String> = Util.getScriptClassName(o);
+    if (oScriptCls != null && ((PolymodScriptClass.blacklistedScriptClassStaticFields.get(oScriptCls)?.contains(f) ?? false)
+      || (PolymodScriptClass.blacklistedScriptClassInstanceFields.get(oScriptCls)?.contains(f) ?? false)))
+    {
+      error(EBlacklistedField(f));
+      return null;
     }
 
     // Otherwise, we assume the field is fine to use.

--- a/polymod/hscript/_internal/Interp.hx
+++ b/polymod/hscript/_internal/Interp.hx
@@ -568,20 +568,20 @@ class Interp
 
 
   /**
-   * Given a class declaration, fetches all fields with the `@:blacklisted` metadata and adds it to the script class blacklist.
+   * Given a class declaration, fetches all fields with the `@:unreflective` metadata and adds it to the script class blacklist.
    * @param cls The class declaration.
    */
   static function registerScriptClassBlacklist(cls:ClassDecl):Void
   {
     var clsName:String = Util.getFullClassName(cls);
-    if (cls.meta.length > 0 && cls.meta.findIndex((m) -> return m.name == ':blacklisted') != -1)
+    if (cls.meta.length > 0 && cls.meta.findIndex((m) -> return m.name == ':unreflective') != -1)
     {
       Polymod.blacklistScriptClassImport(clsName);
     }
 
-    // Filter fields to see which have the `@:blacklisted` metadata.
-    var staticFields:Array<String> = [for (field in cls.staticFields.filter((f) -> f.meta.length > 0 && f.meta.findIndex((m) -> return m.name == ':blacklisted') != -1)) field.name];
-    var instanceFields:Array<String> = [for (field in cls.fields.filter((f) -> f.meta.length > 0 && f.meta.findIndex((m) -> return m.name == ':blacklisted') != -1)) field.name];
+    // Filter fields to see which have the `@:unreflective` metadata.
+    var staticFields:Array<String> = [for (field in cls.staticFields.filter((f) -> f.meta.length > 0 && f.meta.findIndex((m) -> return m.name == ':unreflective') != -1)) field.name];
+    var instanceFields:Array<String> = [for (field in cls.fields.filter((f) -> f.meta.length > 0 && f.meta.findIndex((m) -> return m.name == ':unreflective') != -1)) field.name];
 
     if (staticFields.length > 0)
       Polymod.blacklistScriptClassStaticFields(clsName, staticFields);

--- a/polymod/hscript/_internal/PolymodScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodScriptClass.hx
@@ -50,6 +50,24 @@ class PolymodScriptClass
    */
   public static final blacklistedInstanceFields:Map<String, Array<String>> = new Map<String, Array<String>>();
 
+  /*
+   * List of blacklisted full package script classes that aren't able to be imported.
+   * Cleared everytime scripts are reset.
+   */
+  public static var blacklistedScriptClasses:Array<String> = [];
+
+  /**
+   * Provide a scripted class with an array of its static fields to blacklist them.
+   * Blacklisted fields cannot be gotten or set.
+   */
+  public static final blacklistedScriptClassStaticFields:Map<String, Array<String>> = new Map<String, Array<String>>();
+
+  /**
+   * Provide a scripted class with an array of its static fields to blacklist them.
+   * Blacklisted fields cannot be gotten or set.
+   */
+  public static final blacklistedScriptClassInstanceFields:Map<String, Array<String>> = new Map<String, Array<String>>();
+
   /**
    * Field names that may not be reached even through a receiver whose type is not known.
    */
@@ -552,6 +570,10 @@ class PolymodScriptClass
   public static function clearScriptedClasses():Void
   {
     scriptInterp.clearScriptClassDescriptors();
+
+    blacklistedScriptClasses = [];
+    blacklistedScriptClassStaticFields.clear();
+    blacklistedScriptClassInstanceFields.clear();
   }
 
   /**

--- a/polymod/hscript/_internal/PolymodStaticClassReference.hx
+++ b/polymod/hscript/_internal/PolymodStaticClassReference.hx
@@ -42,7 +42,7 @@ class PolymodStaticClassReference
     #end
 
     @:privateAccess {
-      if (Interp._scriptClassDescriptors.exists(clsName))
+      if (Interp._scriptClassDescriptors.exists(clsName) && !PolymodScriptClass.blacklistedScriptClasses.contains(clsName))
       {
         return new PolymodStaticClassReference(Interp._scriptClassDescriptors.get(clsName));
       }

--- a/polymod/util/Util.hx
+++ b/polymod/util/Util.hx
@@ -7,6 +7,9 @@ import polymod.format.BaseParseFormat;
 import polymod.format.ParseRules;
 import polymod.fs.PolymodFileSystem.IFileSystem;
 import polymod.hscript._internal.Expr;
+import polymod.hscript._internal.Interp;
+import polymod.hscript._internal.PolymodScriptClass;
+import polymod.hscript._internal.PolymodStaticClassReference;
 #if unifill
 import unifill.Unifill;
 #end
@@ -778,6 +781,24 @@ class Util
       default:
         Std.string(type);
     }
+  }
+
+  public static function getScriptClassName(cls:Dynamic):Null<String>
+  {
+    var clsName:Null<String> = null;
+    if (Std.isOfType(cls, PolymodStaticClassReference))
+    {
+      clsName = cast(cls, PolymodStaticClassReference).getFullyQualifiedName();
+    }
+    else if (Std.isOfType(cls, PolymodScriptClass))
+    {
+      clsName = cast(cls, PolymodScriptClass).fullyQualifiedName;
+    }
+    else if (Std.isOfType(cls, String))
+    {
+      clsName = getFullClassName(Interp.findScriptClassDescriptor(cast cls));
+    }
+    return clsName;
   }
 
   /**


### PR DESCRIPTION
This PR adds being able to blacklist other scripted classes, and fields of other scripted classes like how you can blacklist other classes.

## How it works
**Blacklisting Scripted Classes**
When making a script class, you can blacklist the script by putting the `@:blacklisted` metadata over the class as shown below.
<img width="911" height="266" alt="image" src="https://github.com/user-attachments/assets/a4a53489-e773-4e7d-ab99-c3e8b143fa24" />

**Blacklisting Script Classes Fields**
Similarly to blacklisting whole script classes, you're able to blacklist any fields or functions of a script class be inserting the `@:blacklisted` metadata.
<img width="1020" height="364" alt="image" src="https://github.com/user-attachments/assets/d75fcd29-27f1-4a14-a866-f3051a15e27c" />