### PR TITLE
[OPTIMIZATION/BUGFIX] Cache scripted class function calls

### DIFF
--- a/polymod/hscript/_internal/PolymodAbstractScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodAbstractScriptClass.hx
@@ -26,9 +26,7 @@ abstract PolymodAbstractScriptClass(PolymodScriptClass) from PolymodScriptClass
       case _:
         if (this.findFunction(name) != null)
         {
-          return Reflect.makeVarArgs(function(args:Array<Dynamic>) {
-            return this.callFunction(name, args);
-          });
+          return this._cachedFunctionCalls.get(name);
         }
         else if (this.findVar(name) != null)
         {

--- a/polymod/hscript/_internal/PolymodScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodScriptClass.hx
@@ -1134,6 +1134,7 @@ class PolymodScriptClass
     if (_cachedFunctionDecls != null)
     {
       _cachedFunctionDecls.remove(name);
+      _cachedFunctionCalls.remove(name);
     }
   }
 
@@ -1204,6 +1205,7 @@ class PolymodScriptClass
   private var _cachedFieldDecls:Map<String, FieldDecl> = [];
   private var _cachedSuperFunctionDecls:Map<String, Dynamic> = [];
   private var _cachedFunctionDecls:Map<String, FunctionDecl> = [];
+  private var _cachedFunctionCalls:Map<String, Dynamic> = [];
   private var _cachedVarDecls:Map<String, VarDecl> = [];
   private var _cachedUsingFunctions:Map<String, Array<Dynamic>->Dynamic> = [];
 
@@ -1212,6 +1214,7 @@ class PolymodScriptClass
     _cachedFieldDecls.clear();
     _cachedSuperFunctionDecls.clear();
     _cachedFunctionDecls.clear();
+    _cachedFunctionCalls.clear();
     _cachedVarDecls.clear();
     _cachedUsingFunctions.clear();
 
@@ -1229,6 +1232,10 @@ class PolymodScriptClass
       {
         case KFunction(fn):
           _cachedFunctionDecls.set(f.name, fn);
+          _cachedFunctionCalls.set(f.name, Reflect.makeVarArgs(function(args:Array<Dynamic>)
+          {
+            return callFunction(f.name, args);
+          }));
         case KVar(v):
           _cachedVarDecls.set(f.name, v);
           if (v.expr != null)


### PR DESCRIPTION
This PR caches the instance functions of a scripted class when they're retrieved.

Related issues this fixes is like how when using `FlxSignal`, if you add a function then you're never able to remove it because a different function is always created at memory when referenced due to `Reflect.makeVarArgs()`.

## Old
<img width="500" height="462" alt="image" src="https://github.com/user-attachments/assets/c6ea9e64-1f47-4bd1-b2c1-c402fc2360e8" />
<img width="513" height="61" alt="image" src="https://github.com/user-attachments/assets/98eaf582-8945-4c20-a02b-9adf8cf07e3d" />

## New
<img width="343" height="39" alt="image" src="https://github.com/user-attachments/assets/7160c425-f455-49ee-ba46-96867eadd440" />
