### PR TITLE
[BUGFIX] Fix non-class declared local vars

### DIFF
--- a/polymod/hscript/_internal/Interp.hx
+++ b/polymod/hscript/_internal/Interp.hx
@@ -763,9 +763,15 @@ class Interp
       }
     }
 
-    // Fallback to setting in local scope.
-    variables.set(id, v);
-    return v;
+    if (_proxy != null && _proxy.fieldExists(id) || variables.exists(id))
+    {
+      // Fallback to setting in local scope.
+      variables.set(id, v);
+      return v;
+    }
+
+    error(EUnknownVariable(id));
+    return null;
   }
 
   /**


### PR DESCRIPTION
Fixes: [#413](https://github.com/FunkinCrew/polymod/issues/413)

This PR fixes a bug where you're able to declare a local variable without needing to add `final` or `var` to it.
**Note: This PR is a breaking change for scripts that utilized this bug.
As far as I know there's a couple of hxc files in Funkin' where this bug is used like `nene.hxc`** 