### PR TITLE
[VULNERABILITY] Fix usingCache bypassing blacklisted functions

### DIFF
--- a/polymod/hscript/_internal/PolymodScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodScriptClass.hx
@@ -1286,6 +1286,8 @@ class PolymodScriptClass
 
         for (fld in fields)
         {
+          if(blacklistedStaticFields.exists(u.cls) && blacklistedStaticFields.get(u.cls).contains(fld)) continue;
+          
           var field:Dynamic = Reflect.getProperty(u.cls, fld);
           if (!Reflect.isFunction(field)) continue;
 


### PR DESCRIPTION
hi this is not fun now so 

### Example
`using funkin.Assets`
`var lib = "".getLibrary()`